### PR TITLE
Add usage-monitor

### DIFF
--- a/registry/usage-monitor.json
+++ b/registry/usage-monitor.json
@@ -1,0 +1,7 @@
+{
+  "id": "usage-monitor",
+  "repo": "ABorakati/paseo-usage-monitor",
+  "categories": ["monitoring", "productivity"],
+  "caveats": ["Reads credentials from the CLIs and files each provider already stores locally"],
+  "submittedBy": "ABorakati"
+}


### PR DESCRIPTION
Registers the Usage Monitor plugin: live provider quota/balance dashboard, cumulative token usage history, and configurable composer pills. Repo: https://github.com/ABorakati/paseo-usage-monitor