### PR TITLE
feat(registry): add pr-radar

### DIFF
--- a/registry/pr-radar.json
+++ b/registry/pr-radar.json
@@ -1,0 +1,10 @@
+{
+  "id": "pr-radar",
+  "repo": "omercnet/paseo-pr-radar",
+  "categories": ["monitoring", "productivity", "github"],
+  "caveats": [
+    "Requires an authenticated gh CLI on the daemon host",
+    "Requires Paseo 0.7.0-beta.3 or newer"
+  ],
+  "submittedBy": "omercnet"
+}


### PR DESCRIPTION
## Summary

- register `omercnet/paseo-pr-radar`
- classify it for monitoring, productivity, and GitHub workflows
- surface its authenticated `gh` and Paseo requirements

## Validation

- `bun run registry:validate`