### PR TITLE
feat(registry): add shared-browser

### DIFF
--- a/registry/shared-browser.json
+++ b/registry/shared-browser.json
@@ -1,0 +1,10 @@
+{
+  "id": "shared-browser",
+  "repo": "omercnet/paseo-shared-browser",
+  "categories": ["browser", "productivity"],
+  "caveats": [
+    "Installs a dedicated Chromium download of roughly 180 MB on the daemon host",
+    "Downloads, uploads, clipboard sync, media permissions, and extensions are disabled"
+  ],
+  "submittedBy": "omercnet"
+}


### PR DESCRIPTION
## Summary

- register `omercnet/paseo-shared-browser`
- classify it for browser and productivity workflows
- surface the Chromium download and intentionally unsupported browser capabilities

## Validation

- `bun run registry:validate`