### PR TITLE
Add monokai-pro registry entry

### DIFF
--- a/registry/monokai-pro.json
+++ b/registry/monokai-pro.json
@@ -1,0 +1,11 @@
+{
+  "id": "monokai-pro",
+  "repo": "JrDw0/paseo-monokai-pro",
+  "categories": ["theme"],
+  "caveats": [
+    "Requires Paseo 0.8 or newer; 0.8 builds that reject the manifest requirements key need the v0.2.0 tag",
+    "Paseo 0.7 hosts need the v0.1.0 tag",
+    "Code blocks keep Paseo's built-in syntax theme — plugins cannot contribute one"
+  ],
+  "submittedBy": "JrDw0"
+}


### PR DESCRIPTION
## What

One hand-written file: `registry/monokai-pro.json`, pointing at <https://github.com/JrDw0/paseo-monokai-pro>
— seven Monokai Pro filter schemes (Pro, Light, Classic, Machine, Ristretto, Octagon, Spectrum) as
app themes via `addTheme`.

Submitting here because [omercnet/awesome-paseo-plugins](https://github.com/omercnet/awesome-paseo-plugins)
is archived and its README redirects to this repo. My entry there
([#21](https://github.com/omercnet/awesome-paseo-plugins/pull/21)) merged into the archive snapshot.

## Checks

```
$ bun run registry:validate
✓ 11 registry entries validated OK.

$ bun run lint:app
Checked 79 files in 221ms. No fixes applied.
```

`registry/monokai-pro.json` is Biome-formatted, and the `id` matches both the filename and the
plugin's `paseo-plugin.json`.

## Caveats — why three lines instead of one version

Paseo's plugin runtime changed twice around 0.8, so the plugin publishes three refs:

| Host | Ref |
| ---- | --- |
| 0.8.0-beta.1+ | `main` (manifest declares `requirements.paseo: "^0.8.0"`) |
| 0.8 builds that load `index.client.ts` but reject the `requirements` key (nightlies still labeled 0.7.2) | `v0.2.0` |
| 0.7.x (single `index.ts` entry) | `v0.1.0` |

0.8 hosts reject a plugin that declares no `requirements.paseo`, so `main` declares it — which in
turn cannot be parsed by the transitional builds. The third caveat is a plugin-API limit worth
stating before install: plugins cannot contribute syntax palettes, so code blocks keep Paseo's
built-in highlight theme.

Install verified on a host running the v0.8 runtime entries layout:
`paseo plugin add JrDw0/paseo-monokai-pro` → `running`, no error.