### PR TITLE
Fix plugin runtime boundary scanning

### DIFF
--- a/scripts/plugin-security/static-scan.test.ts
+++ b/scripts/plugin-security/static-scan.test.ts
@@ -42,6 +42,91 @@ describe("scanStaticFiles", () => {
     expect(result.findings.some((f) => f.ruleId === "legacy-index")).toBe(false)
   })
 
+  it("allows client and server modules to import shared modules", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    const plugin = join(root, "plugin")
+    mkdirSync(join(plugin, "client"), { recursive: true })
+    mkdirSync(join(plugin, "server"), { recursive: true })
+    mkdirSync(join(plugin, "shared"), { recursive: true })
+    writeFileSync(
+      join(plugin, "paseo-plugin.json"),
+      JSON.stringify({ id: "plugin" })
+    )
+    writeFileSync(
+      join(plugin, "shared", "contract.ts"),
+      "export const contract = {}"
+    )
+    writeFileSync(
+      join(plugin, "client", "view.ts"),
+      'import { contract } from "../shared/contract"\nexport { contract }'
+    )
+    writeFileSync(
+      join(plugin, "server", "handler.ts"),
+      'import { contract } from "../shared/contract"\nexport { contract }'
+    )
+
+    const result = scanStaticFiles({
+      root,
+      pluginPath: "plugin",
+      registryId: "plugin",
+    })
+
+    expect(
+      result.findings.filter(
+        (finding) => finding.ruleId === "cross-runtime-import"
+      )
+    ).toEqual([])
+  })
+
+  it("flags imports between incompatible plugin runtimes", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    const plugin = join(root, "plugin")
+    mkdirSync(join(plugin, "client"), { recursive: true })
+    mkdirSync(join(plugin, "server"), { recursive: true })
+    mkdirSync(join(plugin, "shared"), { recursive: true })
+    writeFileSync(
+      join(plugin, "paseo-plugin.json"),
+      JSON.stringify({ id: "plugin" })
+    )
+    writeFileSync(
+      join(plugin, "client", "view.ts"),
+      'import "../server/handler"'
+    )
+    writeFileSync(
+      join(plugin, "server", "handler.ts"),
+      'import "../client/view"'
+    )
+    writeFileSync(
+      join(plugin, "shared", "from-client.ts"),
+      'export { view } from "../client/view"'
+    )
+    writeFileSync(
+      join(plugin, "shared", "from-server.ts"),
+      'export { handler } from "../server/handler"'
+    )
+    writeFileSync(join(plugin, "index.client.ts"), 'import "./server/handler"')
+    writeFileSync(join(plugin, "index.server.ts"), 'import "./client/view"')
+
+    const result = scanStaticFiles({
+      root,
+      pluginPath: "plugin",
+      registryId: "plugin",
+    })
+    const paths = result.findings
+      .filter((finding) => finding.ruleId === "cross-runtime-import")
+      .map((finding) => finding.path)
+      .sort()
+
+    expect(paths).toEqual([
+      "client/view.ts",
+      "index.client.ts",
+      "index.server.ts",
+      "server/handler.ts",
+      "shared/from-client.ts",
+      "shared/from-server.ts",
+    ])
+  })
+
   it("flags symlinks", () => {
     const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
     const plugin = join(root, "plugin")

--- a/scripts/plugin-security/static-scan.ts
+++ b/scripts/plugin-security/static-scan.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 import { lstatSync, readdirSync, readFileSync } from "node:fs"
-import { join, relative, resolve } from "node:path"
+import { dirname, join, normalize, relative, resolve } from "node:path"
 import * as semver from "semver"
+import * as ts from "typescript"
 import type { SecurityFinding } from "./shared.ts"
 
 export type StaticScanInput = {
@@ -208,14 +209,63 @@ function validateEntrypoint(
       )
     )
 }
+type PluginRuntime = "client" | "server" | "shared"
+
+function runtimeForPath(path: string): PluginRuntime | null {
+  const parts = path.split(/[\\/]/)
+  const directory = parts.length > 1 ? parts[0] : undefined
+  if (
+    directory === "client" ||
+    directory === "server" ||
+    directory === "shared"
+  )
+    return directory
+
+  const filename = parts.at(-1)
+  if (/^index\.client\.(?:ts|tsx)$/.test(filename ?? "")) return "client"
+  if (/^index\.server\.(?:ts|tsx)$/.test(filename ?? "")) return "server"
+  return null
+}
+
+function importedRuntime(
+  path: string,
+  specifier: string
+): PluginRuntime | null {
+  if (specifier.startsWith("."))
+    return runtimeForPath(normalize(join(dirname(path), specifier)))
+
+  const directory = specifier.split("/")[0]
+  return directory === "client" ||
+    directory === "server" ||
+    directory === "shared"
+    ? directory
+    : null
+}
+
+function crossesRuntimeBoundary(
+  source: PluginRuntime,
+  target: PluginRuntime
+): boolean {
+  if (source === "shared") return target !== "shared"
+  if (source === "client") return target === "server"
+  return target === "client"
+}
+
 function scanBoundaries(
   content: string,
   path: string,
   findings: SecurityFinding[]
 ) {
+  if (!/\.(?:[cm]?[jt]s|[jt]sx)$/.test(path)) return
+  const source = runtimeForPath(path)
+  if (!source) return
+
+  const imports = ts.preProcessFile(content, true, true).importedFiles
   if (
-    /from\s+["']\.\.\/(client|server|shared)\//.test(content) ||
-    /from\s+["'](?:client|server|shared)\//.test(content)
+    imports.some(({ fileName }) => {
+      const target = importedRuntime(path, fileName)
+      return target !== null && crossesRuntimeBoundary(source, target)
+    })
   )
     findings.push(
       finding(


### PR DESCRIPTION
## Problem

The security scanner treats every `../shared/...` import as a cross-runtime violation. The Paseo Plugin SDK explicitly permits client and server modules to import shared modules, so valid plugins such as `github-board` receive blocking false positives.

## Fix

- classify each source file as client, server, or shared
- resolve relative import targets before comparing runtimes
- allow same-runtime imports and client/server imports from shared
- continue blocking client-to-server, server-to-client, and shared-to-runtime-specific imports
- use TypeScript's import preprocessor instead of matching source text

This addresses the false positives reported in https://github.com/paseo-cafe/paseo-cafe/pull/19#issuecomment-5601149984.

## Verification

- `bunx vitest run scripts/plugin-security/static-scan.test.ts`
- `bun run security:test`
- `bun run check`