### PR TITLE
Explain plugin security scan failures

### DIFF
--- a/scripts/plugin-security/publish.test.ts
+++ b/scripts/plugin-security/publish.test.ts
@@ -73,6 +73,18 @@ describe("publishReport", () => {
     expect(called).toBe(false)
   })
 
+  it("preserves collapsible report tags while neutralizing untrusted HTML", () => {
+    const bounded = boundedReport(
+      "<details>\n<summary>Rule guidance</summary>\n<b>@team</b>\n</details>"
+    )
+
+    expect(bounded).toContain("<details>")
+    expect(bounded).toContain("<summary>Rule guidance</summary>")
+    expect(bounded).toContain("</details>")
+    expect(bounded).not.toContain("<b>")
+    expect(bounded).not.toContain("@team")
+  })
+
   it("bounds and neutralizes untrusted report content", () => {
     const report = `<b>@team</b>${"x".repeat(70_000)}`
     const bounded = boundedReport(report)

--- a/scripts/plugin-security/publish.ts
+++ b/scripts/plugin-security/publish.ts
@@ -78,6 +78,10 @@ export function boundedReport(report: string): string {
     .replaceAll("@", "@\u200b")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
+    .replace(
+      /&lt;(\/?(?:details|summary))&gt;/g,
+      (_match, tag: string) => `<${tag}>`
+    )
   if (sanitized.length <= MAX_COMMENT_LENGTH) return sanitized
   return `${sanitized.slice(0, MAX_COMMENT_LENGTH)}\n\n_Report truncated._`
 }

--- a/scripts/plugin-security/scan.test.ts
+++ b/scripts/plugin-security/scan.test.ts
@@ -1,11 +1,76 @@
 import { describe, expect, it } from "vitest"
+import { renderReport } from "./scan.ts"
+import type { SecurityResults } from "./shared.ts"
 
-describe("scan cli", () => {
-  it("keeps static-only semantics honest", () => {
-    expect(true).toBe(true)
+describe("security report", () => {
+  it("renders deduplicated rule guidance for findings", () => {
+    const results: SecurityResults = {
+      version: 1,
+      generatedAt: "2026-09-09T00:00:00.000Z",
+      plugins: {
+        example: {
+          commit: "abc123",
+          scannedAt: "2026-09-09T00:00:00.000Z",
+          status: "failed",
+          blockingFindings: 2,
+          advisoryFindings: 0,
+          coverage: { files: 2, bytes: 100 },
+          buildCommands: [],
+          findings: [
+            {
+              tool: "boundary",
+              ruleId: "cross-runtime-import",
+              severity: "high",
+              blocking: true,
+              path: "client/one.ts",
+              message: "cross-runtime import boundary violated",
+            },
+            {
+              tool: "boundary",
+              ruleId: "cross-runtime-import",
+              severity: "high",
+              blocking: true,
+              path: "client/two.ts",
+              message: "cross-runtime import boundary violated",
+            },
+          ],
+        },
+      },
+    }
+
+    const report = renderReport(results)
+
+    expect(report).toContain("<details>")
+    expect(report).toContain(
+      "<summary>Why these rules failed and how to fix them</summary>"
+    )
+    expect(report).toContain("**Issue:** The import crosses bundles")
+    expect(report).toContain(
+      "**Fix:** Keep UI and React Native code under `client/`"
+    )
+    expect(report.match(/### `boundary\/cross-runtime-import`/g)).toHaveLength(
+      1
+    )
   })
 
-  it("fails clone timeouts as blocking", () => {
-    expect(true).toBe(true)
+  it("omits rule guidance when a plugin has no findings", () => {
+    const results: SecurityResults = {
+      version: 1,
+      generatedAt: "2026-09-09T00:00:00.000Z",
+      plugins: {
+        example: {
+          commit: "abc123",
+          scannedAt: "2026-09-09T00:00:00.000Z",
+          status: "passed",
+          blockingFindings: 0,
+          advisoryFindings: 0,
+          coverage: { files: 2, bytes: 100 },
+          buildCommands: [],
+          findings: [],
+        },
+      },
+    }
+
+    expect(renderReport(results)).not.toContain("<details>")
   })
 })

--- a/scripts/plugin-security/scan.ts
+++ b/scripts/plugin-security/scan.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { z } from "zod"
 import type {
+  SecurityFinding,
   SecurityPluginResult,
   SecurityResults,
   SecurityTarget,
@@ -13,47 +14,52 @@ import { scanStaticFiles } from "./static-scan.ts"
 
 const CLONE_TIMEOUT_MS = 60_000
 
-const args = process.argv.slice(2)
-const targetsPath = valueFor(args, "--targets")
-const reportPath = valueFor(args, "--report")
-const jsonPath = valueFor(args, "--json")
+function main() {
+  const args = process.argv.slice(2)
+  const targetsPath = valueFor(args, "--targets")
+  const reportPath = valueFor(args, "--report")
+  const jsonPath = valueFor(args, "--json")
 
-if (!targetsPath || !reportPath) {
-  throw new Error("missing --targets or --report")
+  if (!targetsPath || !reportPath) {
+    throw new Error("missing --targets or --report")
+  }
+
+  const targets = z
+    .object({
+      version: z.literal(1),
+      targets: z.array(
+        z.object({
+          id: z.string(),
+          repo: z.string(),
+          path: z.string().optional(),
+          ref: z.string(),
+          commit: z.string(),
+        })
+      ),
+    })
+    .parse(JSON.parse(readFileSync(targetsPath, "utf8")))
+
+  const generatedAt = new Date().toISOString()
+  const results: SecurityResults = { version: 1, generatedAt, plugins: {} }
+  for (const target of targets.targets) {
+    results.plugins[target.id] = scanTarget(target, generatedAt)
+  }
+
+  writeFileSync(reportPath, renderReport(results))
+  if (jsonPath) {
+    writeFileSync(jsonPath, `${JSON.stringify(results, null, 2)}\n`)
+  }
+  if (
+    Object.values(results.plugins).some((plugin) => plugin.blockingFindings > 0)
+  ) {
+    process.exitCode = 1
+  }
 }
 
-const targets = z
-  .object({
-    version: z.literal(1),
-    targets: z.array(
-      z.object({
-        id: z.string(),
-        repo: z.string(),
-        path: z.string().optional(),
-        ref: z.string(),
-        commit: z.string(),
-      })
-    ),
-  })
-  .parse(JSON.parse(readFileSync(targetsPath, "utf8")))
-
-const generatedAt = new Date().toISOString()
-const results: SecurityResults = { version: 1, generatedAt, plugins: {} }
-for (const target of targets.targets) {
-  results.plugins[target.id] = scanTarget(target)
-}
-
-writeFileSync(reportPath, renderReport(results))
-if (jsonPath) {
-  writeFileSync(jsonPath, `${JSON.stringify(results, null, 2)}\n`)
-}
-if (
-  Object.values(results.plugins).some((plugin) => plugin.blockingFindings > 0)
-) {
-  process.exitCode = 1
-}
-
-function scanTarget(target: SecurityTarget): SecurityPluginResult {
+function scanTarget(
+  target: SecurityTarget,
+  generatedAt: string
+): SecurityPluginResult {
   const temp = mkdtempSync(join(tmpdir(), "paseo-plugin-security-"))
   try {
     const repoDir = join(temp, "repo")
@@ -145,7 +151,104 @@ function scrubEnv() {
   return env
 }
 
-function renderReport(results: SecurityResults) {
+type RuleGuidance = {
+  issue: string
+  fix: string
+}
+
+const RULE_GUIDANCE: Record<string, RuleGuidance> = {
+  "scanner/incomplete": {
+    issue:
+      "The scanner could not inspect the complete plugin, so a clean result cannot be trusted.",
+    fix: "Keep the plugin within 200 files, 2 MiB total, 2 MiB per file, and six directory levels. Resolve any accompanying scanner finding first.",
+  },
+  "scanner/symlink": {
+    issue:
+      "Symlinks can escape the reviewed plugin tree or change what code is loaded after review.",
+    fix: "Replace the symlink with a regular file or directory inside the plugin.",
+  },
+  "scanner/size-limit": {
+    issue: "The scanner skipped a file larger than its 2 MiB inspection limit.",
+    fix: "Remove generated artifacts from the plugin or reduce the file below 2 MiB.",
+  },
+  "scanner/scan-error": {
+    issue:
+      "The scanner could not clone, resolve, or inspect the submitted plugin revision.",
+    fix: "Verify the repository, ref, and plugin path are accessible and correct, then rerun the check.",
+  },
+  "manifest/id": {
+    issue:
+      "The plugin manifest is missing an id or its id differs from the registry entry.",
+    fix: "Set `paseo-plugin.json` → `id` to the exact registry id.",
+  },
+  "manifest/requirements": {
+    issue: "The manifest's `requirements` value is not an object.",
+    fix: 'Use an object such as `{ "paseo": ">=0.8.0" }`.',
+  },
+  "manifest/requirements.paseo": {
+    issue: "The declared Paseo requirement is not a valid npm semver range.",
+    fix: "Use a valid range such as `>=0.8.0` or `>=0.8.3 <0.9.0`.",
+  },
+  "manifest/build": {
+    issue:
+      "Build commands must be explicit argument arrays so they run without a shell.",
+    fix: 'Use a non-empty array of non-empty argv arrays, for example `[["bun", "install", "--frozen-lockfile"]]`.',
+  },
+  "manifest/unknown": {
+    issue:
+      "The manifest contains a key the current plugin format does not recognize.",
+    fix: "Remove the key. Supported top-level keys are `id`, `requirements`, and `build`.",
+  },
+  "manifest/json": {
+    issue: "The scanner could not parse `paseo-plugin.json`.",
+    fix: "Make the manifest valid JSON without comments or trailing commas.",
+  },
+  "entrypoint/legacy-index": {
+    issue: "Paseo 0.8 no longer loads the legacy `index.ts` plugin entrypoint.",
+    fix: "Move app contributions to `index.client.ts` or `.tsx`, daemon contributions to `index.server.ts`, or provide both.",
+  },
+  "boundary/cross-runtime-import": {
+    issue:
+      "The import crosses bundles that run in different environments. Client code cannot load server code, server code cannot load client code, and shared code cannot depend on either runtime.",
+    fix: "Keep UI and React Native code under `client/`, Node code under `server/`, and runtime-neutral contracts and values under `shared/`. Client and server modules may both import shared modules.",
+  },
+}
+
+function guidanceKey(finding: SecurityFinding): string {
+  if (finding.tool === "manifest" && finding.ruleId.startsWith("unknown:"))
+    return "manifest/unknown"
+  return `${finding.tool}/${finding.ruleId}`
+}
+
+function renderRuleGuidance(findings: SecurityFinding[]): string[] {
+  const rules = new Map<string, RuleGuidance>()
+  for (const finding of findings) {
+    const key = guidanceKey(finding)
+    const guidance = RULE_GUIDANCE[key]
+    if (guidance) rules.set(key, guidance)
+  }
+  if (rules.size === 0) return []
+
+  const lines = [
+    "<details>",
+    "<summary>Why these rules failed and how to fix them</summary>",
+    "",
+  ]
+  for (const [rule, guidance] of rules) {
+    lines.push(
+      `### \`${rule}\``,
+      "",
+      `**Issue:** ${guidance.issue}`,
+      "",
+      `**Fix:** ${guidance.fix}`,
+      ""
+    )
+  }
+  lines.push("</details>")
+  return lines
+}
+
+export function renderReport(results: SecurityResults) {
   const lines = ["# Security Scan", `Generated: ${results.generatedAt}`, ""]
   for (const [id, plugin] of Object.entries(results.plugins)) {
     lines.push(
@@ -161,6 +264,8 @@ function renderReport(results: SecurityResults) {
         `- [${finding.tool}] ${finding.ruleId} ${finding.path}${finding.line ? `:${finding.line}` : ""} ${finding.message}`
       )
     }
+    const guidance = renderRuleGuidance(plugin.findings)
+    if (guidance.length > 0) lines.push("", ...guidance)
     lines.push("")
   }
   return lines.join("\n")
@@ -170,3 +275,5 @@ function valueFor(argv: string[], flag: string) {
   const index = argv.indexOf(flag)
   return index >= 0 ? argv[index + 1] : undefined
 }
+
+if (import.meta.main) main()


### PR DESCRIPTION
## Problem

Security scan comments identify failing rules, but do not explain why each rule exists or how a plugin author should fix it.

## Change

- add issue and remediation guidance for every current scanner rule
- render guidance once per unique failed rule in a collapsed `<details>` section
- preserve only the safe `details` and `summary` tags through comment sanitization
- keep untrusted HTML and GitHub mentions neutralized
- make report rendering import-safe and directly testable

## Verification

- `bun run security:test`
- `bun run check`