### PR TITLE
Fix plugin security scan byte accounting

### DIFF
--- a/scripts/plugin-security/static-scan.test.ts
+++ b/scripts/plugin-security/static-scan.test.ts
@@ -145,7 +145,41 @@ describe("scanStaticFiles", () => {
     expect(result.findings.some((f) => f.ruleId === "incomplete")).toBe(true)
   })
 
+  it("excludes Git metadata from coverage", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    mkdirSync(join(root, ".git", "objects"), { recursive: true })
+    const manifest = JSON.stringify({ id: "plugin" })
+    writeFileSync(join(root, "paseo-plugin.json"), manifest)
+    writeFileSync(
+      join(root, ".git", "objects", "pack"),
+      Buffer.alloc(2_000_001)
+    )
+
+    const result = scanStaticFiles({ root, registryId: "plugin" })
+
+    expect(result.files).toBe(1)
+    expect(result.bytes).toBe(Buffer.byteLength(manifest))
+    expect(result.findings).toEqual([])
+  })
+
+  it("counts binary files by their on-disk size", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    const binary = Buffer.from([0xff, 0xfe])
+    writeFileSync(join(root, "artifact.bin"), binary)
+
+    const result = scanStaticFiles({ root })
+
+    expect(result.files).toBe(1)
+    expect(result.bytes).toBe(binary.byteLength)
+  })
+
   it("fails closed on oversized files", () => {
-    expect(true).toBe(true)
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    writeFileSync(join(root, "artifact.bin"), Buffer.alloc(2_000_001))
+
+    const result = scanStaticFiles({ root })
+
+    expect(result.findings.some((f) => f.ruleId === "size-limit")).toBe(true)
+    expect(result.findings.some((f) => f.ruleId === "incomplete")).toBe(true)
   })
 })

--- a/scripts/plugin-security/static-scan.ts
+++ b/scripts/plugin-security/static-scan.ts
@@ -56,6 +56,7 @@ function walk(
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name)
     const rel = relative(base, full) || entry.name
+    if (entry.isDirectory() && entry.name === ".git") continue
     if (entry.isSymbolicLink()) {
       state.incomplete = true
       findings.push(
@@ -86,7 +87,7 @@ function walk(
     state.files += 1
     if (state.files > MAX_FILES) state.incomplete = true
     const content = readFileSync(full, "utf8")
-    state.bytes += Buffer.byteLength(content)
+    state.bytes += meta.size
     if (state.bytes > MAX_BYTES) state.incomplete = true
     if (entry.name === "paseo-plugin.json")
       validateManifest(content, rel, registryId, findings, buildCommands)


### PR DESCRIPTION
## Problem

The security scanner traverses cloned repositories' `.git` metadata and computes coverage by decoding every file as UTF-8 before measuring it. Binary Git pack files and plugin assets can therefore inflate the byte count and cause false `incomplete` failures. This blocked #18 even though the plugin source was within the configured limits.

## Changes

- exclude `.git` directories from static plugin scans
- count file bytes using filesystem metadata instead of UTF-8 decoded content
- replace the placeholder size-limit test with coverage for Git metadata, binary byte accounting, and oversized files

## Verification

- `bunx vitest run scripts/plugin-security/static-scan.test.ts`
- `bunx biome check scripts/plugin-security/static-scan.ts scripts/plugin-security/static-scan.test.ts`
- reproduced the scan against `supermomonga/paseo-plugin-zcode-provider@971afdb0a2d8f4ed2e7b8d26ca2b19bef2155de6`: passed with 67 files, 847,544 bytes, and no findings

Fixes the false security scan failure reported on #18.