### PR TITLE
Harden plugin security report guidance

### DIFF
--- a/scripts/plugin-security/publish.test.ts
+++ b/scripts/plugin-security/publish.test.ts
@@ -3,6 +3,12 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import { boundedReport, publishReport, REPORT_MARKER } from "./publish.ts"
+import {
+  REPORT_DETAILS_CLOSE,
+  REPORT_DETAILS_OPEN,
+  REPORT_SUMMARY_CLOSE,
+  REPORT_SUMMARY_OPEN,
+} from "./shared.ts"
 
 describe("publishReport", () => {
   it("creates a marker comment and writes the job summary", async () => {
@@ -73,9 +79,14 @@ describe("publishReport", () => {
     expect(called).toBe(false)
   })
 
-  it("preserves collapsible report tags while neutralizing untrusted HTML", () => {
+  it("restores only trusted collapsible markup tokens", () => {
     const bounded = boundedReport(
-      "<details>\n<summary>Rule guidance</summary>\n<b>@team</b>\n</details>"
+      [
+        REPORT_DETAILS_OPEN,
+        `${REPORT_SUMMARY_OPEN}Rule guidance${REPORT_SUMMARY_CLOSE}`,
+        "<b>@team</b>",
+        REPORT_DETAILS_CLOSE,
+      ].join("\n")
     )
 
     expect(bounded).toContain("<details>")
@@ -85,12 +96,32 @@ describe("publishReport", () => {
     expect(bounded).not.toContain("@team")
   })
 
-  it("bounds and neutralizes untrusted report content", () => {
-    const report = `<b>@team</b>${"x".repeat(70_000)}`
-    const bounded = boundedReport(report)
-    expect(bounded.length).toBeLessThan(61_000)
+  it("does not promote raw or encoded disclosure tags to markup", () => {
+    const bounded = boundedReport(
+      "<details>\n&lt;summary&gt;fake&lt;/summary&gt;\n</details>"
+    )
+
+    expect(bounded).not.toContain("<details>")
+    expect(bounded).not.toContain("<summary>")
+  })
+
+  it("bounds reports at complete lines", () => {
+    const line = `- finding ${"x".repeat(390)}`
+    const bounded = boundedReport(
+      Array.from({ length: 200 }, () => line).join("\n")
+    )
+    const notice = "\n\n_Report truncated._"
+    const body = bounded.slice(0, -notice.length)
+
+    expect(bounded.length).toBeLessThanOrEqual(60_000)
+    expect(bounded.endsWith(notice)).toBe(true)
+    expect(body.split("\n").at(-1)).toBe(line)
+  })
+
+  it("neutralizes untrusted report content", () => {
+    const bounded = boundedReport("<b>@team</b>")
+
     expect(bounded).not.toContain("<b>")
     expect(bounded).not.toContain("@team")
-    expect(bounded).toContain("_Report truncated._")
   })
 })

--- a/scripts/plugin-security/publish.test.ts
+++ b/scripts/plugin-security/publish.test.ts
@@ -113,7 +113,7 @@ describe("publishReport", () => {
     const notice = "\n\n_Report truncated._"
     const body = bounded.slice(0, -notice.length)
 
-    expect(bounded.length).toBeLessThanOrEqual(60_000)
+    expect(`${REPORT_MARKER}\n${bounded}`.length).toBeLessThanOrEqual(60_000)
     expect(bounded.endsWith(notice)).toBe(true)
     expect(body.split("\n").at(-1)).toBe(line)
   })

--- a/scripts/plugin-security/publish.ts
+++ b/scripts/plugin-security/publish.ts
@@ -9,6 +9,7 @@ import {
 
 export const REPORT_MARKER = "<!-- paseo-plugin-security-report -->"
 const MAX_COMMENT_LENGTH = 60_000
+const MAX_REPORT_LENGTH = MAX_COMMENT_LENGTH - `${REPORT_MARKER}\n`.length
 const TRUNCATION_NOTICE = "\n\n_Report truncated._"
 const REPORT_MARKUP: Record<string, string> = {
   [REPORT_DETAILS_OPEN]: "<details>",
@@ -94,9 +95,9 @@ export function boundedReport(report: string): string {
   for (const [token, markup] of Object.entries(REPORT_MARKUP)) {
     sanitized = sanitized.replaceAll(token, markup)
   }
-  if (sanitized.length <= MAX_COMMENT_LENGTH) return sanitized
+  if (sanitized.length <= MAX_REPORT_LENGTH) return sanitized
 
-  const budget = MAX_COMMENT_LENGTH - TRUNCATION_NOTICE.length
+  const budget = MAX_REPORT_LENGTH - TRUNCATION_NOTICE.length
   const lineBreak = sanitized.lastIndexOf("\n", budget)
   const end = lineBreak > 0 ? lineBreak : budget
   return `${sanitized.slice(0, end)}${TRUNCATION_NOTICE}`

--- a/scripts/plugin-security/publish.ts
+++ b/scripts/plugin-security/publish.ts
@@ -1,8 +1,21 @@
 #!/usr/bin/env bun
 import { appendFileSync, readFileSync } from "node:fs"
+import {
+  REPORT_DETAILS_CLOSE,
+  REPORT_DETAILS_OPEN,
+  REPORT_SUMMARY_CLOSE,
+  REPORT_SUMMARY_OPEN,
+} from "./shared.ts"
 
 export const REPORT_MARKER = "<!-- paseo-plugin-security-report -->"
 const MAX_COMMENT_LENGTH = 60_000
+const TRUNCATION_NOTICE = "\n\n_Report truncated._"
+const REPORT_MARKUP: Record<string, string> = {
+  [REPORT_DETAILS_OPEN]: "<details>",
+  [REPORT_DETAILS_CLOSE]: "</details>",
+  [REPORT_SUMMARY_OPEN]: "<summary>",
+  [REPORT_SUMMARY_CLOSE]: "</summary>",
+}
 
 type PullRequestEvent = {
   pull_request?: { number?: number }
@@ -73,17 +86,20 @@ export async function publishReport(options: PublishOptions): Promise<void> {
 }
 
 export function boundedReport(report: string): string {
-  const sanitized = report
+  let sanitized = report
     .replaceAll("\0", "")
     .replaceAll("@", "@\u200b")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
-    .replace(
-      /&lt;(\/?(?:details|summary))&gt;/g,
-      (_match, tag: string) => `<${tag}>`
-    )
+  for (const [token, markup] of Object.entries(REPORT_MARKUP)) {
+    sanitized = sanitized.replaceAll(token, markup)
+  }
   if (sanitized.length <= MAX_COMMENT_LENGTH) return sanitized
-  return `${sanitized.slice(0, MAX_COMMENT_LENGTH)}\n\n_Report truncated._`
+
+  const budget = MAX_COMMENT_LENGTH - TRUNCATION_NOTICE.length
+  const lineBreak = sanitized.lastIndexOf("\n", budget)
+  const end = lineBreak > 0 ? lineBreak : budget
+  return `${sanitized.slice(0, end)}${TRUNCATION_NOTICE}`
 }
 
 async function main() {

--- a/scripts/plugin-security/scan.test.ts
+++ b/scripts/plugin-security/scan.test.ts
@@ -1,44 +1,56 @@
 import { describe, expect, it } from "vitest"
+import { boundedReport } from "./publish.ts"
 import { renderReport } from "./scan.ts"
-import type { SecurityResults } from "./shared.ts"
+import {
+  REPORT_DETAILS_OPEN,
+  type SecurityFinding,
+  type SecurityPluginResult,
+  type SecurityResults,
+} from "./shared.ts"
+
+function pluginResult(findings: SecurityFinding[]): SecurityPluginResult {
+  const blockingFindings = findings.filter((finding) => finding.blocking).length
+  return {
+    commit: "abc123",
+    scannedAt: "2026-09-09T00:00:00.000Z",
+    status: blockingFindings > 0 ? "failed" : "passed",
+    blockingFindings,
+    advisoryFindings: findings.length - blockingFindings,
+    coverage: { files: findings.length, bytes: 100 },
+    buildCommands: [],
+    findings,
+  }
+}
+
+function securityResults(plugins: SecurityResults["plugins"]): SecurityResults {
+  return {
+    version: 1,
+    generatedAt: "2026-09-09T00:00:00.000Z",
+    plugins,
+  }
+}
+
+function boundaryFinding(path: string): SecurityFinding {
+  return {
+    tool: "boundary",
+    ruleId: "cross-runtime-import",
+    severity: "high",
+    blocking: true,
+    path,
+    message: "cross-runtime import boundary violated",
+  }
+}
 
 describe("security report", () => {
-  it("renders deduplicated rule guidance for findings", () => {
-    const results: SecurityResults = {
-      version: 1,
-      generatedAt: "2026-09-09T00:00:00.000Z",
-      plugins: {
-        example: {
-          commit: "abc123",
-          scannedAt: "2026-09-09T00:00:00.000Z",
-          status: "failed",
-          blockingFindings: 2,
-          advisoryFindings: 0,
-          coverage: { files: 2, bytes: 100 },
-          buildCommands: [],
-          findings: [
-            {
-              tool: "boundary",
-              ruleId: "cross-runtime-import",
-              severity: "high",
-              blocking: true,
-              path: "client/one.ts",
-              message: "cross-runtime import boundary violated",
-            },
-            {
-              tool: "boundary",
-              ruleId: "cross-runtime-import",
-              severity: "high",
-              blocking: true,
-              path: "client/two.ts",
-              message: "cross-runtime import boundary violated",
-            },
-          ],
-        },
-      },
-    }
-
-    const report = renderReport(results)
+  it("renders each rule's guidance once across all plugins", () => {
+    const report = boundedReport(
+      renderReport(
+        securityResults({
+          first: pluginResult([boundaryFinding("client/one.ts")]),
+          second: pluginResult([boundaryFinding("client/two.ts")]),
+        })
+      )
+    )
 
     expect(report).toContain("<details>")
     expect(report).toContain(
@@ -53,24 +65,78 @@ describe("security report", () => {
     )
   })
 
-  it("omits rule guidance when a plugin has no findings", () => {
-    const results: SecurityResults = {
-      version: 1,
-      generatedAt: "2026-09-09T00:00:00.000Z",
-      plugins: {
-        example: {
-          commit: "abc123",
-          scannedAt: "2026-09-09T00:00:00.000Z",
-          status: "passed",
-          blockingFindings: 0,
-          advisoryFindings: 0,
-          coverage: { files: 2, bytes: 100 },
-          buildCommands: [],
-          findings: [],
-        },
-      },
-    }
+  it("keeps finding data from injecting report markup", () => {
+    const attack = [
+      "client/file.ts",
+      "<details>",
+      "<summary>fake result</summary>",
+      "&lt;details&gt;",
+      REPORT_DETAILS_OPEN,
+    ].join("\n")
+    const report = boundedReport(
+      renderReport(
+        securityResults({ example: pluginResult([boundaryFinding(attack)]) })
+      )
+    )
 
-    expect(renderReport(results)).not.toContain("<details>")
+    expect(report.match(/<details>/g)).toHaveLength(1)
+    expect(report.match(/<summary>/g)).toHaveLength(1)
+    expect(report).not.toContain("<summary>fake result</summary>")
+    expect(report).not.toContain(REPORT_DETAILS_OPEN)
+    expect(report).toContain("\\n")
+  })
+
+  it("keeps guidance complete when a long findings list is truncated", () => {
+    const findings = Array.from({ length: 200 }, (_, index) =>
+      boundaryFinding(
+        `client/${String(index).padStart(3, "0")}-${"x".repeat(400)}.ts`
+      )
+    )
+    const report = boundedReport(
+      renderReport(securityResults({ example: pluginResult(findings) }))
+    )
+
+    expect(report.length).toBeLessThanOrEqual(60_000)
+    expect(report).toContain("<details>")
+    expect(report).toContain("</details>")
+    expect(report).toContain("### `boundary/cross-runtime-import`")
+    const notice = "\n\n_Report truncated._"
+    const lastPublishedLine = report.slice(0, -notice.length).split("\n").at(-1)
+    expect(report.endsWith(notice)).toBe(true)
+    expect(lastPublishedLine).toMatch(/^- \[boundary\].*boundary violated$/)
+  })
+
+  it("states the scanner's decimal byte limit exactly", () => {
+    const finding: SecurityFinding = {
+      tool: "scanner",
+      ruleId: "size-limit",
+      severity: "high",
+      blocking: true,
+      path: "large.ts",
+      message: "file exceeds size budget",
+    }
+    const report = boundedReport(
+      renderReport(securityResults({ example: pluginResult([finding]) }))
+    )
+
+    expect(report).toContain("2,000,000 bytes")
+    expect(report).not.toContain("MiB")
+  })
+
+  it("fails report generation when a rule has no guidance", () => {
+    const finding = { ...boundaryFinding("client/file.ts"), ruleId: "new-rule" }
+    const results = securityResults({ example: pluginResult([finding]) })
+
+    expect(() => renderReport(results)).toThrowError(
+      "missing rule guidance for boundary/new-rule"
+    )
+  })
+
+  it("omits rule guidance when a plugin has no findings", () => {
+    const report = boundedReport(
+      renderReport(securityResults({ example: pluginResult([]) }))
+    )
+
+    expect(report).not.toContain("<details>")
   })
 })

--- a/scripts/plugin-security/scan.ts
+++ b/scripts/plugin-security/scan.ts
@@ -4,11 +4,15 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { z } from "zod"
-import type {
-  SecurityFinding,
-  SecurityPluginResult,
-  SecurityResults,
-  SecurityTarget,
+import {
+  REPORT_DETAILS_CLOSE,
+  REPORT_DETAILS_OPEN,
+  REPORT_SUMMARY_CLOSE,
+  REPORT_SUMMARY_OPEN,
+  type SecurityFinding,
+  type SecurityPluginResult,
+  type SecurityResults,
+  type SecurityTarget,
 } from "./shared.ts"
 import { scanStaticFiles } from "./static-scan.ts"
 
@@ -160,7 +164,7 @@ const RULE_GUIDANCE: Record<string, RuleGuidance> = {
   "scanner/incomplete": {
     issue:
       "The scanner could not inspect the complete plugin, so a clean result cannot be trusted.",
-    fix: "Keep the plugin within 200 files, 2 MiB total, 2 MiB per file, and six directory levels. Resolve any accompanying scanner finding first.",
+    fix: "Keep the plugin within 200 files, 2 MB (2,000,000 bytes) total, 2 MB per file, and six directory levels. Resolve any accompanying scanner finding first.",
   },
   "scanner/symlink": {
     issue:
@@ -168,8 +172,8 @@ const RULE_GUIDANCE: Record<string, RuleGuidance> = {
     fix: "Replace the symlink with a regular file or directory inside the plugin.",
   },
   "scanner/size-limit": {
-    issue: "The scanner skipped a file larger than its 2 MiB inspection limit.",
-    fix: "Remove generated artifacts from the plugin or reduce the file below 2 MiB.",
+    issue: "The scanner skipped a file larger than its 2 MB inspection limit.",
+    fix: "Remove generated artifacts from the plugin or reduce the file below 2,000,000 bytes.",
   },
   "scanner/scan-error": {
     issue:
@@ -220,18 +224,28 @@ function guidanceKey(finding: SecurityFinding): string {
   return `${finding.tool}/${finding.ruleId}`
 }
 
+function escapeReportText(value: string): string {
+  return value
+    .replace(/[\uE000\uE001]/g, "�")
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\r", "\\r")
+    .replaceAll("\n", "\\n")
+    .replace(/([`*_[\]{}()#+\-.!|~])/g, "\\$1")
+}
+
 function renderRuleGuidance(findings: SecurityFinding[]): string[] {
   const rules = new Map<string, RuleGuidance>()
   for (const finding of findings) {
     const key = guidanceKey(finding)
     const guidance = RULE_GUIDANCE[key]
-    if (guidance) rules.set(key, guidance)
+    if (!guidance) throw new Error(`missing rule guidance for ${key}`)
+    rules.set(key, guidance)
   }
   if (rules.size === 0) return []
 
   const lines = [
-    "<details>",
-    "<summary>Why these rules failed and how to fix them</summary>",
+    REPORT_DETAILS_OPEN,
+    `${REPORT_SUMMARY_OPEN}Why these rules failed and how to fix them${REPORT_SUMMARY_CLOSE}`,
     "",
   ]
   for (const [rule, guidance] of rules) {
@@ -244,28 +258,37 @@ function renderRuleGuidance(findings: SecurityFinding[]): string[] {
       ""
     )
   }
-  lines.push("</details>")
+  lines.push(REPORT_DETAILS_CLOSE)
   return lines
 }
 
 export function renderReport(results: SecurityResults) {
-  const lines = ["# Security Scan", `Generated: ${results.generatedAt}`, ""]
+  const lines = [
+    "# Security Scan",
+    `Generated: ${escapeReportText(results.generatedAt)}`,
+    "",
+  ]
+  const findings = Object.values(results.plugins).flatMap(
+    (plugin) => plugin.findings
+  )
+  const guidance = renderRuleGuidance(findings)
+  if (guidance.length > 0) lines.push(...guidance, "")
+
   for (const [id, plugin] of Object.entries(results.plugins)) {
     lines.push(
-      `## ${id}`,
+      `## ${escapeReportText(id)}`,
       `Status: ${plugin.status}`,
-      `Commit: ${plugin.commit}`,
+      `Commit: ${escapeReportText(plugin.commit)}`,
       `Blocking findings: ${plugin.blockingFindings}`,
       `Advisory findings: ${plugin.advisoryFindings}`,
       ""
     )
     for (const finding of plugin.findings) {
+      const location = `${finding.path}${finding.line ? `:${finding.line}` : ""}`
       lines.push(
-        `- [${finding.tool}] ${finding.ruleId} ${finding.path}${finding.line ? `:${finding.line}` : ""} ${finding.message}`
+        `- [${escapeReportText(finding.tool)}] ${escapeReportText(finding.ruleId)} ${escapeReportText(location)} ${escapeReportText(finding.message)}`
       )
     }
-    const guidance = renderRuleGuidance(plugin.findings)
-    if (guidance.length > 0) lines.push("", ...guidance)
     lines.push("")
   }
   return lines.join("\n")

--- a/scripts/plugin-security/shared.ts
+++ b/scripts/plugin-security/shared.ts
@@ -1,5 +1,10 @@
 export const SECURITY_RESULT_VERSION = 1 as const
 
+export const REPORT_DETAILS_OPEN = "\uE000paseo-details-open\uE001"
+export const REPORT_DETAILS_CLOSE = "\uE000paseo-details-close\uE001"
+export const REPORT_SUMMARY_OPEN = "\uE000paseo-summary-open\uE001"
+export const REPORT_SUMMARY_CLOSE = "\uE000paseo-summary-close\uE001"
+
 export type SecurityFinding = {
   tool: string
   ruleId: string


### PR DESCRIPTION
## Problem

The collapsible guidance added in #23 could restore attacker-controlled disclosure tags, lose guidance during character-level truncation, repeat guidance across plugins, and silently omit help for new rules. Its size-limit copy also described 2,000,000 bytes as 2 MiB.

## Fix

- represent trusted disclosure markup with private report tokens and strip those token delimiters from untrusted fields
- escape newlines and Markdown punctuation in all interpolated finding data
- keep raw and entity-encoded disclosure tags escaped
- render one deduplicated guidance section across the complete report
- put guidance before verbose findings and truncate only at complete line boundaries
- reserve space for the comment marker, truncation notice, and complete finding lines within the 60,000-character limit
- fail report generation when an emitted rule has no guidance
- describe the scanner limit as 2 MB (2,000,000 bytes)

## Verification

- `bun run security:test`
- `bun run check`