### PR TITLE
Remove legacy registry ID fields

### DIFF
--- a/registry/agent-crew.json
+++ b/registry/agent-crew.json
@@ -1,5 +1,4 @@
 {
-  "id": "agent-crew",
   "repo": "omercnet/paseo-agent-crew",
   "categories": ["monitoring", "productivity", "orchestration"],
   "caveats": ["Requires Paseo 0.7.2 or newer"],

--- a/registry/agent-monitor.json
+++ b/registry/agent-monitor.json
@@ -1,5 +1,4 @@
 {
-  "id": "agent-monitor",
   "repo": "omercnet/paseo-agent-monitor",
   "categories": ["monitoring", "productivity"],
   "platforms": ["macos", "linux", "windows"],

--- a/registry/launchd-jobs.json
+++ b/registry/launchd-jobs.json
@@ -1,5 +1,4 @@
 {
-  "id": "launchd-jobs",
   "repo": "gpambrozio/paseo-plugins",
   "path": "launchd-jobs",
   "categories": ["automation"],

--- a/registry/paseo-dracula.json
+++ b/registry/paseo-dracula.json
@@ -1,5 +1,4 @@
 {
-  "id": "paseo-dracula",
   "repo": "omercnet/paseo-dracula",
   "categories": ["theme"],
   "caveats": ["Requires Paseo 0.7.2 or newer"],

--- a/registry/pr-radar.json
+++ b/registry/pr-radar.json
@@ -1,5 +1,4 @@
 {
-  "id": "pr-radar",
   "repo": "omercnet/paseo-pr-radar",
   "categories": ["monitoring", "productivity", "github"],
   "caveats": [

--- a/registry/shared-browser.json
+++ b/registry/shared-browser.json
@@ -1,5 +1,4 @@
 {
-  "id": "shared-browser",
   "repo": "omercnet/paseo-shared-browser",
   "categories": ["browser", "productivity"],
   "caveats": [

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,5 +1,4 @@
 {
-  "id": "skills",
   "repo": "gpambrozio/paseo-plugins",
   "path": "skills",
   "categories": ["productivity"]

--- a/registry/subagent-activity.json
+++ b/registry/subagent-activity.json
@@ -1,5 +1,4 @@
 {
-  "id": "subagent-activity",
   "repo": "mcowger/paseo-plugins",
   "path": "subagent-activity",
   "categories": ["monitoring"]

--- a/registry/usage-monitor.json
+++ b/registry/usage-monitor.json
@@ -1,5 +1,4 @@
 {
-  "id": "usage-monitor",
   "repo": "ABorakati/paseo-usage-monitor",
   "categories": ["monitoring", "productivity"],
   "caveats": [

--- a/registry/workspace-activity.json
+++ b/registry/workspace-activity.json
@@ -1,5 +1,4 @@
 {
-  "id": "workspace-activity",
   "repo": "ABorakati/paseo-workspace-activity",
   "categories": ["monitoring", "productivity"],
   "submittedBy": "ABorakati"

--- a/scripts/validate-registry.ts
+++ b/scripts/validate-registry.ts
@@ -72,13 +72,6 @@ async function main() {
     }
     const entry = parsed.data
 
-    if (entry.id !== undefined && entry.id !== expectedId) {
-      problems.push({
-        file,
-        message: `legacy registry id "${entry.id}" must match filename "${file}"`,
-      })
-    }
-
     const [owner, repo] = entry.repo.split("/")
 
     try {

--- a/src/lib/registry-schema.test.ts
+++ b/src/lib/registry-schema.test.ts
@@ -69,11 +69,11 @@ describe("registryEntrySchema", () => {
     expect(result.success).toBe(false)
   })
 
-  it("accepts a legacy registry id during migration", () => {
+  it("rejects a redundant registry id field", () => {
     const result = registryEntrySchema.safeParse({
       id: "plugin",
       repo: "owner/repo",
     })
-    expect(result.success).toBe(true)
+    expect(result.success).toBe(false)
   })
 })

--- a/src/lib/registry-schema.ts
+++ b/src/lib/registry-schema.ts
@@ -33,8 +33,6 @@ export const registryIdSchema = z
  */
 export const registryEntrySchema = z
   .object({
-    /** Transitional compatibility for registry entries created before filename-derived IDs. */
-    id: registryIdSchema.optional(),
     /** GitHub "owner/repo". Just the repo, not a full URL. */
     repo: z
       .string()


### PR DESCRIPTION
## Summary
- remove the redundant `id` property from all 10 registry entries
- remove transitional schema support for registry-level IDs
- reject future registry entries that repeat the filename-derived ID
- keep `paseo-plugin.json.id` as the canonical plugin ID, validated against the registry filename

Follow-up to #24. The trusted `pull_request_target` scanner on `main` now supports filename-derived IDs, so this cleanup can pass Plugin security without weakening that workflow's trust boundary.

## Verification
- `bun run registry:validate` (10 entries passed)
- focused registry and security tests (22 passed)
- `bun run check`
- `bun run test` (90 passed)
- `bun run build`