### PR TITLE
Authenticate registry scans in Zerops builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ registry/<id>.json      →  scripts/validate-registry.ts (CI, on PR)
    on protected `main`. Zerops runs a persistent Bun server (via [Nitro](https://nitro.build), wired
    up in `vite.config.ts`), so Vite/Nitro can inline `data/plugins.json` into the server bundle.
 
+The Zerops `app` service must define `GITHUB_TOKEN` as a secret runtime variable. Zerops exposes it
+to the build as `RUNTIME_GITHUB_TOKEN`; `zerops.yaml` limits the credential to the registry scan and
+fails the deployment before scanning when the secret is absent.
+
 ## Submitting a plugin
 
 The full walkthrough (with a prefilled "create this file on GitHub" button) lives on the site

--- a/zerops.yaml
+++ b/zerops.yaml
@@ -7,7 +7,9 @@ zerops:
       base: bun@1.3
       buildCommands:
         - bun install --frozen-lockfile
-        - bun run build
+        - test -n "$RUNTIME_GITHUB_TOKEN"
+        - GITHUB_TOKEN="$RUNTIME_GITHUB_TOKEN" bun run registry:scan
+        - bun run build:generated
 
       # Nitro (wired up in vite.config.ts) bundles the SSR build into a
       # single self-contained server at .output/server/index.mjs with all


### PR DESCRIPTION
## Summary
- require the Zerops `GITHUB_TOKEN` runtime secret before production builds
- expose the token only to `registry:scan`, then build from the generated catalog
- document the required Zerops secret

## Verification
- `bun install --frozen-lockfile`
- authenticated `bun run registry:scan`
- `bun run build:generated`

The authenticated scan completed cleanly, including `agent-monitor`, and the production bundle was generated.