### PR TITLE
feat(registry): add paseo-cafe

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,34 @@
+# Paseo Cafe
+
+Browse the [paseo.cafe](https://paseo.cafe) plugin catalog from inside Paseo, and install
+plugins without leaving the app.
+
+The plugin adds a **Paseo Cafe** sidebar surface listing every plugin in the catalog with its
+description, categories, platforms, Paseo version requirement, caveats, health checks, and
+screenshots. Searching and filtering happen on the client; installing runs `paseo plugin add`
+on the daemon host behind a confirmation step. A **Paseo plugin** composer attachment source
+lets you attach a plugin's full listing to a prompt when you want an agent to review it before
+you trust it.
+
+## Install
+
+```bash
+paseo plugin add paseo-cafe/paseo-cafe:plugin
+```
+
+Requires a Paseo 0.8 release; the manifest declares `requirements.paseo` as `^0.8.0`.
+
+By default the catalog is read from `https://paseo.cafe/api/plugins`. Point **Settings →
+Plugins → Paseo Cafe** at another deployment (a local `bun run dev`, a staging build, or a
+self-hosted fork) that serves the same shape. `PASEO_CAFE_DIRECTORY_URL` on the daemon is a
+lower-priority fallback for hosts that cannot persist plugin settings.
+
+## Limitations
+
+- Plugins listed here are community-submitted and are not vetted by paseo.cafe. They are
+  trusted, unsandboxed code on your daemon host: read the source before installing.
+- Installing shells out to the `paseo` CLI, so that binary must be on the daemon's `PATH`.
+- The composer attachment source always searches the default catalog. Paseo calls an
+  attachment search with the query alone, and a plugin's server handler cannot read its own
+  settings, so a custom Catalog URL applies to the sidebar surface only.
+- Catalog responses are cached on the daemon for five minutes. **Refresh** bypasses that cache.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -23,6 +23,10 @@ Plugins → Paseo Cafe** at another deployment (a local `bun run dev`, a staging
 self-hosted fork) that serves the same shape. `PASEO_CAFE_DIRECTORY_URL` on the daemon is a
 lower-priority fallback for hosts that cannot persist plugin settings.
 
+A custom catalog must use HTTPS, or HTTP on loopback (`localhost`, `127.0.0.0/8`, `[::1]`).
+The catalog picks which repositories the install button hands to the `paseo` CLI, so anyone
+able to rewrite a plaintext response chooses what gets installed on the daemon host.
+
 ## Limitations
 
 - Plugins listed here are community-submitted and are not vetted by paseo.cafe. They are

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -2,6 +2,7 @@
   "name": "paseo-cafe-plugin",
   "private": true,
   "version": "0.1.0",
+  "description": "Browse the paseo.cafe plugin catalog inside Paseo and install plugins without leaving the app.",
   "scripts": {
     "typecheck": "tsc --noEmit"
   },

--- a/registry/paseo-cafe.json
+++ b/registry/paseo-cafe.json
@@ -4,7 +4,7 @@
   "categories": ["productivity"],
   "caveats": [
     "Installs plugins by running the paseo CLI on the daemon host",
-    "Browsing the catalog requires the daemon to reach paseo.cafe"
+    "Browsing the catalog requires the daemon to reach the configured catalog URL"
   ],
   "submittedBy": "omercnet"
 }

--- a/registry/paseo-cafe.json
+++ b/registry/paseo-cafe.json
@@ -1,0 +1,10 @@
+{
+  "repo": "paseo-cafe/paseo-cafe",
+  "path": "plugin",
+  "categories": ["productivity"],
+  "caveats": [
+    "Installs plugins by running the paseo CLI on the daemon host",
+    "Browsing the catalog requires the daemon to reach paseo.cafe"
+  ],
+  "submittedBy": "omercnet"
+}


### PR DESCRIPTION
## Summary

Lists this repository's own plugin in the directory it powers. The entry points at `paseo-cafe/paseo-cafe` with `path: "plugin"`, which is where `paseo-plugin.json` (`id: "paseo-cafe"`) already lives on `main`.

```json
{
  "repo": "paseo-cafe/paseo-cafe",
  "path": "plugin",
  "categories": ["productivity"],
  "caveats": [
    "Installs plugins by running the paseo CLI on the daemon host",
    "Browsing the catalog requires the daemon to reach paseo.cafe"
  ],
  "submittedBy": "omercnet"
}
```

## Also included, because the scanner reads them

`scripts/scan.ts` derives the listing from files in the plugin directory, and `plugin/` had neither a README nor a package description, so the entry would have rendered with an empty description and an unchecked "Has a README".

- `plugin/README.md` — what the plugin does, an Install section, and a Limitations section. The scanner turns these into the description fallback plus the install and limitations excerpts shown on the detail page.
- `plugin/package.json` — added `description`, which takes precedence over the README paragraph for the catalog blurb.

No behaviour change; nothing under `plugin/client`, `plugin/server`, or `plugin/shared` is touched.

## Verification

- `bun run registry:validate` — 13 entries OK, including this one resolving against `main`
- `bun run registry:scan` — 13 records, 0 warnings; `paseo-cafe` scans with `scanError: null`, `manifestValid: true`, `paseoVersionRequirement: ^0.8.0`, and `url` resolving to `/tree/main/plugin`
- `bun run check:app` and `bun run check:plugin` pass

The scanner reads the default branch, so the description and README land in the generated listing after this merges, on the next deploy or nightly scan.

## Known health gaps

Two health checks stay unchecked, and neither is something this PR should decide unilaterally:

- **Has a license** — the repository has no `LICENSE` file, so GitHub reports no license for it. Every other listing here is MIT. Worth adding one to the repo root as a separate change; I did not want to assert a license on your behalf.
- **Has tests** — `plugin/` has no test script. The shared validators (`isValidRepo`, `isValidInstallPath`) guard a shell-out and deserve coverage, but the root Vitest project cannot resolve `@getpaseo/plugin` from `plugin/node_modules`, so wiring that up is its own change rather than a drive-by here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the Paseo Cafe plugin, including catalog browsing, search and filtering, installation, composer attachments, configuration options, caching, refresh behavior, and limitations.
  - Added package metadata describing the plugin’s ability to browse and install Paseo Cafe catalog plugins.

- **Registry**
  - Added the Paseo Cafe plugin to the registry with its productivity category, installation caveats, and catalog access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->