### PR TITLE
fix(plugin): require HTTPS for non-loopback catalog URLs

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -23,9 +23,10 @@ Plugins → Paseo Cafe** at another deployment (a local `bun run dev`, a staging
 self-hosted fork) that serves the same shape. `PASEO_CAFE_DIRECTORY_URL` on the daemon is a
 lower-priority fallback for hosts that cannot persist plugin settings.
 
-A custom catalog must use HTTPS, or HTTP on loopback (`localhost`, `127.0.0.0/8`, `[::1]`).
-The catalog picks which repositories the install button hands to the `paseo` CLI, so anyone
-able to rewrite a plaintext response chooses what gets installed on the daemon host.
+A custom catalog must use HTTPS, or HTTP on loopback (`localhost`, `*.localhost`,
+`127.0.0.0/8`, `[::1]`). The catalog picks which repositories the install button hands to the
+`paseo` CLI, so anyone able to rewrite a plaintext response chooses what gets installed on the
+daemon host.
 
 ## Limitations
 

--- a/plugin/client/DirectorySettings.tsx
+++ b/plugin/client/DirectorySettings.tsx
@@ -66,13 +66,13 @@ export function DirectorySettings() {
   return (
     <SettingsSection
       title="Paseo Cafe"
-      info="Point this at another deployment of paseo.cafe — a local `npm run dev`, a staging build, or a self-hosted fork — that serves the same /api/plugins shape."
+      info="Point this at another deployment of paseo.cafe — a local `bun run dev`, a staging build, or a self-hosted fork — that serves the same /api/plugins shape. The catalog picks what the install button hands to the paseo CLI, so it must be HTTPS unless it is on localhost."
     >
       <SettingsCard>
         <SettingsInput
           ref={inputRef}
           label="Catalog URL"
-          hint="e.g. http://localhost:3000/api/plugins"
+          hint="HTTPS, or HTTP on localhost — e.g. http://localhost:3000/api/plugins"
           error={saveError}
           initialValue={values.directoryUrl}
           placeholder={DEFAULT_DIRECTORY_URL}

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { InstalledPlugin } from "../shared/directory"
-import { findInstallations, installedPluginSchema } from "../shared/directory"
+import {
+  DEFAULT_DIRECTORY_URL,
+  findInstallations,
+  installedPluginSchema,
+} from "../shared/directory"
 import {
   buildPaseoInvocation,
   inspectUpdateStatus,
@@ -12,6 +16,7 @@ import {
 } from "./directory"
 
 const originalFetch = globalThis.fetch
+const originalDirectoryUrl = process.env.PASEO_CAFE_DIRECTORY_URL
 
 function plugin(overrides: Record<string, unknown> = {}) {
   return {
@@ -51,6 +56,11 @@ function gitInstallation(
 afterEach(() => {
   globalThis.fetch = originalFetch
   vi.restoreAllMocks()
+  if (originalDirectoryUrl === undefined) {
+    delete process.env.PASEO_CAFE_DIRECTORY_URL
+  } else {
+    process.env.PASEO_CAFE_DIRECTORY_URL = originalDirectoryUrl
+  }
 })
 
 describe("listDirectory", () => {
@@ -77,6 +87,7 @@ describe("listDirectory", () => {
     expect(fetcher).toHaveBeenCalledWith(baseUrl, {
       signal: expect.any(AbortSignal),
       headers: { accept: "application/json" },
+      redirect: "error",
     })
   })
 
@@ -97,6 +108,66 @@ describe("listDirectory", () => {
     ).rejects.toThrow(
       "https://unavailable.example.test/plugins returned 503 Service Unavailable"
     )
+  })
+})
+
+describe("catalog transport policy", () => {
+  it("fails closed when fetching a catalog encounters a redirect", async () => {
+    const trustedUrl = "https://catalog.example/api/plugins"
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(
+        new TypeError(`UnexpectedRedirect fetching ${trustedUrl}`)
+      )
+
+    await expect(
+      listDirectory({ baseUrl: trustedUrl, force: true })
+    ).rejects.toThrow("UnexpectedRedirect")
+    expect(fetchSpy).toHaveBeenCalledWith(
+      trustedUrl,
+      expect.objectContaining({ redirect: "error" })
+    )
+  })
+
+  it("redacts and warns once about a rejected environment URL", async () => {
+    const username = "catalog-user"
+    const password = "catalog-credential"
+    const token = "signed-query-value"
+    const rejectedUrl = new URL("http://catalog.example/api/plugins")
+    rejectedUrl.username = username
+    rejectedUrl.password = password
+    rejectedUrl.searchParams.set("token", token)
+    rejectedUrl.hash = "private"
+    process.env.PASEO_CAFE_DIRECTORY_URL = rejectedUrl.href
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, {
+        status: 503,
+        statusText: "Service Unavailable",
+      })
+    )
+
+    await expect(listDirectory({ force: true })).rejects.toThrow(
+      `${DEFAULT_DIRECTORY_URL} returned 503 Service Unavailable`
+    )
+    await expect(listDirectory({ force: true })).rejects.toThrow(
+      `${DEFAULT_DIRECTORY_URL} returned 503 Service Unavailable`
+    )
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      DEFAULT_DIRECTORY_URL,
+      expect.any(Object)
+    )
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Ignoring PASEO_CAFE_DIRECTORY_URL: catalog URL must use HTTPS, or HTTP on localhost."
+    )
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.stringify(errorSpy.mock.calls)
+    expect(logged).not.toContain(username)
+    expect(logged).not.toContain(password)
+    expect(logged).not.toContain(token)
+    expect(logged).not.toContain("catalog.example")
   })
 })
 

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -112,6 +112,18 @@ describe("listDirectory", () => {
 })
 
 describe("catalog transport policy", () => {
+  it("rejects an untrusted explicit URL before fetching it", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+    await expect(
+      listDirectory({
+        baseUrl: "http://catalog.internal/api/plugins",
+        force: true,
+      })
+    ).rejects.toThrow("Catalog URL must use HTTPS, or HTTP on localhost.")
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
   it("fails closed when fetching a catalog encounters a redirect", async () => {
     const trustedUrl = "https://catalog.example/api/plugins"
     const fetchSpy = vi

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -289,7 +289,12 @@ function resolveDirectoryUrl(baseUrl: string | undefined): string {
   // PASEO_CAFE_DIRECTORY_URL is a lower-priority escape hatch for contexts that
   // cannot persist plugin settings yet (CI, headless smoke tests). The settings
   // override wins because it is reachable from the running app.
-  if (baseUrl) return baseUrl
+  if (baseUrl) {
+    if (!isTrustedCatalogUrl(baseUrl)) {
+      throw new Error("Catalog URL must use HTTPS, or HTTP on localhost.")
+    }
+    return baseUrl
+  }
   const fromEnv = process.env.PASEO_CAFE_DIRECTORY_URL
   if (!fromEnv) return DEFAULT_DIRECTORY_URL
   // Unlike the settings value this never passed a schema, so it gets the same

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -283,6 +283,7 @@ const cache = new Map<
     plugins: z.infer<typeof directoryEntrySchema>[]
   }
 >()
+let warnedAboutRejectedDirectoryUrl = false
 
 function resolveDirectoryUrl(baseUrl: string | undefined): string {
   // PASEO_CAFE_DIRECTORY_URL is a lower-priority escape hatch for contexts that
@@ -295,9 +296,12 @@ function resolveDirectoryUrl(baseUrl: string | undefined): string {
   // transport check here; a rejected value falls back instead of silently
   // pointing the install button at an unauthenticated catalog.
   if (isTrustedCatalogUrl(fromEnv)) return fromEnv
-  console.error(
-    `Ignoring PASEO_CAFE_DIRECTORY_URL: ${fromEnv} must use HTTPS, or HTTP on localhost.`
-  )
+  if (!warnedAboutRejectedDirectoryUrl) {
+    console.error(
+      "Ignoring PASEO_CAFE_DIRECTORY_URL: catalog URL must use HTTPS, or HTTP on localhost."
+    )
+    warnedAboutRejectedDirectoryUrl = true
+  }
   return DEFAULT_DIRECTORY_URL
 }
 
@@ -315,6 +319,7 @@ async function fetchDirectory(baseUrl: string | undefined, force = false) {
   try {
     response = await fetch(url, {
       signal: controller.signal,
+      redirect: "error",
       headers: { accept: "application/json" },
     })
   } finally {

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -19,6 +19,7 @@ import {
   getSiteUrl,
   HEALTH_LABELS,
   installedPluginSchema,
+  isTrustedCatalogUrl,
   isValidInstallPath,
   isValidRepo,
   stripHtml,
@@ -287,9 +288,17 @@ function resolveDirectoryUrl(baseUrl: string | undefined): string {
   // PASEO_CAFE_DIRECTORY_URL is a lower-priority escape hatch for contexts that
   // cannot persist plugin settings yet (CI, headless smoke tests). The settings
   // override wins because it is reachable from the running app.
-  return (
-    baseUrl || process.env.PASEO_CAFE_DIRECTORY_URL || DEFAULT_DIRECTORY_URL
+  if (baseUrl) return baseUrl
+  const fromEnv = process.env.PASEO_CAFE_DIRECTORY_URL
+  if (!fromEnv) return DEFAULT_DIRECTORY_URL
+  // Unlike the settings value this never passed a schema, so it gets the same
+  // transport check here; a rejected value falls back instead of silently
+  // pointing the install button at an unauthenticated catalog.
+  if (isTrustedCatalogUrl(fromEnv)) return fromEnv
+  console.error(
+    `Ignoring PASEO_CAFE_DIRECTORY_URL: ${fromEnv} must use HTTPS, or HTTP on localhost.`
   )
+  return DEFAULT_DIRECTORY_URL
 }
 
 async function fetchDirectory(baseUrl: string | undefined, force = false) {

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   directoryListRpc,
   directorySettings,
@@ -37,6 +37,7 @@ describe("catalog URL transport policy", () => {
     "https://paseo.cafe/api/plugins",
     "https://catalog.internal/api/plugins",
     "http://localhost:3000/api/plugins",
+    "http://LOCALHOST:3000/api/plugins",
     "http://dev.localhost:3000/api/plugins",
     "http://127.0.0.1:3000/api/plugins",
     "http://127.255.255.255/api/plugins",
@@ -51,9 +52,44 @@ describe("catalog URL transport policy", () => {
     "http://127.0.0.1.evil.example/api/plugins",
     "http://[::2]/api/plugins",
     "ftp://paseo.cafe/api/plugins",
+    "https://[:::]/api/plugins",
     "not a URL",
   ])("rejects untrusted catalog URL %s", (url) => {
     expect(isTrustedCatalogUrl(url)).toBe(false)
+  })
+
+  it("keeps RPC validation independent of the runtime URL parser", () => {
+    class ReactNativeUrl {
+      readonly href: string
+
+      constructor(value: string) {
+        this.href = value
+      }
+
+      get protocol() {
+        return `${this.href.split(":", 1)[0]}:`
+      }
+
+      get hostname() {
+        return this.href.includes("[") ? "[" : "LOCALHOST"
+      }
+    }
+
+    vi.stubGlobal("URL", ReactNativeUrl)
+    try {
+      expect(
+        directoryListRpc.input.safeParse({
+          baseUrl: "http://[::1]:3000/api/plugins",
+        }).success
+      ).toBe(true)
+      expect(
+        directoryUpdateStatusRpc.input.safeParse({
+          baseUrl: "http://LOCALHOST:3000/api/plugins",
+        }).success
+      ).toBe(true)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it("rejects untrusted URLs at every caller-controlled catalog schema", () => {

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   getInstallCommand,
   getSiteUrl,
+  isTrustedCatalogUrl,
   isValidInstallPath,
   isValidRepo,
   stripHtml,
@@ -25,6 +26,31 @@ describe("plugin install targets", () => {
     expect(isValidInstallPath("../plugin")).toBe(false)
     expect(isValidInstallPath("plugin/../../outside")).toBe(false)
     expect(isValidInstallPath("plugin name")).toBe(false)
+  })
+})
+
+describe("catalog URL transport policy", () => {
+  it.each([
+    "https://paseo.cafe/api/plugins",
+    "https://catalog.internal/api/plugins",
+    "http://localhost:3000/api/plugins",
+    "http://dev.localhost:3000/api/plugins",
+    "http://127.0.0.1:3000/api/plugins",
+    "http://127.255.255.255/api/plugins",
+    "http://[::1]:3000/api/plugins",
+  ])("accepts trusted catalog URL %s", (url) => {
+    expect(isTrustedCatalogUrl(url)).toBe(true)
+  })
+
+  it.each([
+    "http://catalog.internal/api/plugins",
+    "http://192.168.1.10/api/plugins",
+    "http://127.0.0.1.evil.example/api/plugins",
+    "http://[::2]/api/plugins",
+    "ftp://paseo.cafe/api/plugins",
+    "not a URL",
+  ])("rejects untrusted catalog URL %s", (url) => {
+    expect(isTrustedCatalogUrl(url)).toBe(false)
   })
 })
 

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
 import {
+  directoryListRpc,
+  directorySettings,
+  directoryUpdateStatusRpc,
   getInstallCommand,
   getSiteUrl,
   isTrustedCatalogUrl,
@@ -51,6 +54,20 @@ describe("catalog URL transport policy", () => {
     "not a URL",
   ])("rejects untrusted catalog URL %s", (url) => {
     expect(isTrustedCatalogUrl(url)).toBe(false)
+  })
+
+  it("rejects untrusted URLs at every caller-controlled catalog schema", () => {
+    const url = "http://catalog.internal/api/plugins"
+
+    expect(
+      directorySettings.schema.safeParse({ directoryUrl: url }).success
+    ).toBe(false)
+    expect(directoryListRpc.input.safeParse({ baseUrl: url }).success).toBe(
+      false
+    )
+    expect(
+      directoryUpdateStatusRpc.input.safeParse({ baseUrl: url }).success
+    ).toBe(false)
   })
 })
 

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -154,7 +154,7 @@ export const directoryListRpc = defineRpc({
 
 export const directoryUpdateStatusRpc = defineRpc({
   name: "directory.update-status",
-  input: z.object({ baseUrl: httpUrlSchema.optional() }),
+  input: z.object({ baseUrl: catalogUrlSchema.optional() }),
   output: z.object({
     installations: z.array(installedPluginSchema).max(500),
   }),

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -16,6 +16,37 @@ const httpUrlSchema = z
   .refine((value) => /^https?:\/\//i.test(value), "Expected an HTTP(S) URL")
 
 /**
+ * Catalog responses decide which repositories the install button hands to the
+ * `paseo` CLI, so the transport has to be authenticated: anyone able to rewrite
+ * a plaintext response picks what gets installed on the daemon host. HTTP is
+ * allowed only for loopback, which is what the local-development workflow in
+ * the README needs; every other catalog has to be HTTPS.
+ */
+export function isTrustedCatalogUrl(value: string): boolean {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return false
+  }
+  if (url.protocol === "https:") return true
+  if (url.protocol !== "http:") return false
+  const host = url.hostname
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "[::1]" ||
+    host === "::1" ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+  )
+}
+
+const catalogUrlSchema = httpUrlSchema.refine(
+  isTrustedCatalogUrl,
+  "Catalog URL must use HTTPS, or HTTP on localhost"
+)
+
+/**
  * Which paseo.cafe deployment to read from — host-scoped so it's one setting
  * per daemon, editable from Settings → Plugins → Paseo Cafe without a
  * reload. Exists for local development (point at `npm run dev`) and for
@@ -26,7 +57,7 @@ export const directorySettings = defineSettings({
   scope: "host",
   version: 1,
   schema: z.object({
-    directoryUrl: httpUrlSchema.default(DEFAULT_DIRECTORY_URL),
+    directoryUrl: catalogUrlSchema.default(DEFAULT_DIRECTORY_URL),
   }),
 })
 
@@ -111,7 +142,7 @@ export const directoryListRpc = defineRpc({
   // baseUrl comes from the client's own directorySettings read — see
   // DirectorySurface.tsx — so the server doesn't need its own settings access.
   input: z.object({
-    baseUrl: httpUrlSchema.optional(),
+    baseUrl: catalogUrlSchema.optional(),
     force: z.boolean().default(false),
   }),
   output: z.object({

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -36,7 +36,6 @@ export function isTrustedCatalogUrl(value: string): boolean {
     host === "localhost" ||
     host.endsWith(".localhost") ||
     host === "[::1]" ||
-    host === "::1" ||
     /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
   )
 }
@@ -49,7 +48,7 @@ const catalogUrlSchema = httpUrlSchema.refine(
 /**
  * Which paseo.cafe deployment to read from — host-scoped so it's one setting
  * per daemon, editable from Settings → Plugins → Paseo Cafe without a
- * reload. Exists for local development (point at `npm run dev`) and for
+ * reload. Exists for local development (point at `bun run dev`) and for
  * anyone running a self-hosted fork of the directory.
  */
 export const directorySettings = defineSettings({

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -22,21 +22,33 @@ const httpUrlSchema = z
  * allowed only for loopback, which is what the local-development workflow in
  * the README needs; every other catalog has to be HTTPS.
  */
+const catalogUrlPattern =
+  /^(https?):\/\/(?:[^/?#@\s\\]*@)?(\[[0-9a-f:.]+\]|[^:/?#@\s\\]+)(?::(\d+))?(?:[/?#]|$)/i
+
 export function isTrustedCatalogUrl(value: string): boolean {
-  let url: URL
   try {
-    url = new URL(value)
+    new URL(value)
   } catch {
     return false
   }
-  if (url.protocol === "https:") return true
-  if (url.protocol !== "http:") return false
-  const host = url.hostname
+  // React Native's URL shim truncates bracketed IPv6 hostnames and preserves
+  // host casing. Parse the authority directly instead of trusting its hostname.
+  const match = catalogUrlPattern.exec(value.trim())
+  if (!match) return false
+  const [, protocol, rawHost, port] = match
+  if (port !== undefined && Number(port) > 65_535) return false
+  if (protocol.toLowerCase() === "https") return true
+  const host = rawHost.toLowerCase()
+  if (host === "localhost" || host.endsWith(".localhost") || host === "[::1]") {
+    return true
+  }
+  const octets = host.split(".")
   return (
-    host === "localhost" ||
-    host.endsWith(".localhost") ||
-    host === "[::1]" ||
-    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+    octets.length === 4 &&
+    octets[0] === "127" &&
+    octets.every(
+      (octet) => /^(0|[1-9]\d{0,2})$/.test(octet) && Number(octet) <= 255
+    )
   )
 }
 


### PR DESCRIPTION
## Problem

The catalog chooses which repository the install button hands to `paseo plugin add` on the daemon host. Plaintext remote catalog responses could therefore be rewritten in transit to select attacker-controlled code. Argument-array execution and repo/path shape validation prevent shell injection, but they do not authenticate the catalog contents.

Raised by CodeRabbit while reviewing #32 (CWE-319).

## Change

- Add `isTrustedCatalogUrl`, accepting HTTPS everywhere and HTTP only for loopback development URLs: `localhost`, `*.localhost`, `127.0.0.0/8`, and `[::1]`.
- Apply the policy to the saved catalog setting, the `directory.list` RPC input, and `PASEO_CAFE_DIRECTORY_URL`.
- Fall back to the default catalog when the environment override is rejected, without logging the rejected value or leaking embedded credentials/tokens.
- Disable redirect following for catalog fetches so a trusted HTTPS URL cannot redirect to an untrusted transport or destination.
- Explain the transport rule in the settings UI.

## Deliberate scope

Content URLs inside catalog entries (`url`, `images`, and `owner.avatarUrl`) keep the broader HTTP(S) rule. They are rendered or opened, not handed to the installer. Arbitrary HTTPS catalog origins also remain supported for self-hosted deployments.

A self-hosted catalog reachable only over plain HTTP on a non-loopback host must move to HTTPS or be tunnelled to localhost.

## Verification

- `bun run check:plugin`
- `npm --prefix plugin run typecheck`
- `npm --prefix plugin test` — 23 tests pass, including URL-policy, redirect, and log-redaction regressions
- GitHub CI: plugin and aggregate checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom catalogs now support HTTP on localhost and loopback addresses, while HTTPS remains required for other catalogs.
  - Catalog URLs are validated more strictly, including port and format checks.
  - Redirects to untrusted catalog destinations are blocked.

- **Bug Fixes**
  - Invalid catalog URLs are rejected consistently across directory settings and catalog actions.
  - Rejected environment-configured catalogs safely fall back to the default catalog.

- **Documentation**
  - Updated setup guidance and input hints to clarify HTTPS requirements and local development commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->