### PR TITLE
fix(plugin): clarify Release Please PR titles

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
     "plugin": {
       "release-type": "node",
       "include-component-in-tag": false,
-      "initial-version": "0.1.0"
+      "initial-version": "0.1.0",
+      "pull-request-title-pattern": "chore(plugin): release ${component} ${version}"
     }
   }
 }


### PR DESCRIPTION
## Summary

- make Release Please PR titles explicitly identify the plugin
- keep generated release PRs distinct from unrelated repository releases