### PR TITLE
feat(plugin): surface available plugin updates

### DIFF
--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -15,13 +15,15 @@ import {
   directoryListRpc,
   directorySettings,
   directoryUpdateRpc,
-  findInstallation,
+  directoryUpdateStatusRpc,
+  findInstallations,
 } from "../shared/directory"
 import { PluginDetailPage } from "./PluginDetailPage"
 import { PluginGalleryPage } from "./PluginGalleryPage"
 import { PluginRow } from "./PluginRow"
 
 const DIRECTORY_QUERY_KEY = "paseo-cafe-directory"
+const UPDATE_STATUS_QUERY_KEY = "paseo-cafe-update-status"
 
 function toggle<T>(set: ReadonlySet<T>, value: T): Set<T> {
   const next = new Set(set)
@@ -118,7 +120,8 @@ type InstallationStatusFilter =
 interface StatusFilterOption {
   value: InstallationStatusFilter
   label: string
-  count: number
+  count?: number
+  disabled?: boolean
 }
 
 function StatusFilterRow({
@@ -146,6 +149,8 @@ function StatusFilterRow({
         marginRight: 2,
       },
       chip: (active: boolean) => ({
+        minHeight: 44,
+        justifyContent: "center" as const,
         borderRadius: 999,
         paddingHorizontal: 10,
         paddingVertical: 5,
@@ -163,21 +168,33 @@ function StatusFilterRow({
   )
 
   return (
-    <View style={styles.row}>
+    <View
+      accessibilityRole="radiogroup"
+      accessibilityLabel="Plugin installation status"
+      style={styles.row}
+    >
       <Text style={styles.label}>Show:</Text>
       {options.map((option) => {
         const active = selected === option.value
+        const countLabel =
+          option.count === undefined ? "unavailable" : `${option.count} plugins`
         return (
           <Pressable
             key={option.value}
-            accessibilityRole="button"
-            accessibilityLabel={`Show ${option.label.toLowerCase()} plugins`}
-            accessibilityState={{ selected: active }}
-            style={styles.chip(active)}
+            accessibilityRole="radio"
+            accessibilityLabel={`${option.label}, ${countLabel}`}
+            accessibilityState={{ checked: active, disabled: option.disabled }}
+            aria-checked={active}
+            aria-disabled={option.disabled}
+            disabled={option.disabled}
+            style={[
+              styles.chip(active),
+              option.disabled ? { opacity: 0.5 } : null,
+            ]}
             onPress={() => onSelect(option.value)}
           >
             <Text style={styles.chipText(active)}>
-              {option.label} {option.count}
+              {option.label} {option.count ?? "—"}
             </Text>
           </Pressable>
         )
@@ -190,6 +207,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
   const listDirectory = useRpc(directoryListRpc)
   const installPlugin = useRpc(directoryInstallRpc)
   const updatePlugin = useRpc(directoryUpdateRpc)
+  const listUpdateStatus = useRpc(directoryUpdateStatusRpc)
   const settings = useSettings(directorySettings)
   const toast = useToast()
   const queryClient = useQueryClient()
@@ -222,6 +240,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
     settings.status === "ready" ? settings.values.directoryUrl : undefined
   const settingsPending = settings.status === "loading"
   const queryKey = [DIRECTORY_QUERY_KEY, baseUrl]
+  const updateStatusQueryKey = [UPDATE_STATUS_QUERY_KEY, baseUrl]
 
   const directoryQuery = useQuery({
     queryKey,
@@ -231,6 +250,13 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
     enabled: !settingsPending,
     staleTime: 60_000,
   })
+  const inventoryAvailable = directoryQuery.data?.installations !== undefined
+  const updateStatusQuery = useQuery({
+    queryKey: updateStatusQueryKey,
+    queryFn: () => listUpdateStatus({ baseUrl }),
+    enabled: inventoryAvailable,
+    staleTime: 60_000,
+  })
 
   const installMutation = useMutation({
     mutationFn: (entry: DirectoryEntry) => {
@@ -238,11 +264,15 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       setInstallFailure(null)
       return installPlugin({ repo: entry.repo, path: entry.path })
     },
-    onSuccess: (result, entry) => {
+    onSuccess: async (result, entry) => {
       if (result.ok) {
         setInstallFailure(null)
         toast.show(`Installed ${entry.name}`, { variant: "success" })
-        void queryClient.invalidateQueries({ queryKey })
+        await queryClient.invalidateQueries({ queryKey, exact: true })
+        await queryClient.invalidateQueries({
+          queryKey: updateStatusQueryKey,
+          exact: true,
+        })
       } else {
         setInstallFailure({ entryId: entry.id, message: result.message })
         toast.error(`Couldn't install ${entry.name}. See details below.`)
@@ -258,6 +288,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
 
   const updateMutation = useMutation({
     mutationFn: ({
+      entry,
       installation,
     }: {
       entry: DirectoryEntry
@@ -265,13 +296,20 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
     }) => {
       setUpdatingId(installation.id)
       setUpdateFailure(null)
-      return updatePlugin({ pluginId: installation.id })
+      return updatePlugin({
+        pluginId: installation.id,
+        entry: { id: entry.id, repo: entry.repo, path: entry.path },
+      })
     },
-    onSuccess: (result, { entry }) => {
+    onSuccess: async (result, { entry }) => {
       if (result.ok) {
         setUpdateFailure(null)
         toast.show(result.message, { variant: "success" })
-        void queryClient.invalidateQueries({ queryKey })
+        await queryClient.invalidateQueries({ queryKey, exact: true })
+        await queryClient.invalidateQueries({
+          queryKey: updateStatusQueryKey,
+          exact: true,
+        })
       } else {
         setUpdateFailure({ entryId: entry.id, message: result.message })
         toast.error(`Couldn't update ${entry.name}. See details below.`)
@@ -292,8 +330,12 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       const key = [DIRECTORY_QUERY_KEY, baseUrl]
       return { key, result: await listDirectory({ baseUrl, force: true }) }
     },
-    onSuccess: ({ key, result }) => {
+    onSuccess: async ({ key, result }) => {
       queryClient.setQueryData(key, result)
+      await queryClient.invalidateQueries({
+        queryKey: updateStatusQueryKey,
+        exact: true,
+      })
       toast.show("Paseo Cafe refreshed.", { variant: "success" })
     },
     onError: (error) => {
@@ -302,34 +344,24 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
   })
 
   const plugins = directoryQuery.data?.plugins ?? []
-  const installations = directoryQuery.data?.installations ?? []
+  const installations = inventoryAvailable
+    ? (updateStatusQuery.data?.installations ??
+      directoryQuery.data?.installations ??
+      [])
+    : []
   const installationByEntryId = useMemo(
     () =>
       new Map(
         plugins.flatMap((entry) => {
-          const installation = findInstallation(entry, installations)
-          return installation ? [[entry.id, installation] as const] : []
+          const matches = findInstallations(entry, installations)
+          return matches.length > 0 ? [[entry.id, matches] as const] : []
         })
       ),
     [plugins, installations]
   )
-  const detailInstallation = detailEntry
-    ? installationByEntryId.get(detailEntry.id)
-    : undefined
-  const installedCount = installationByEntryId.size
-  const updateCount = Array.from(installationByEntryId.values()).filter(
-    (installation) => installation.updateAvailable
-  ).length
-  const statusOptions: readonly StatusFilterOption[] = [
-    { value: "all", label: "All", count: plugins.length },
-    { value: "installed", label: "Installed", count: installedCount },
-    { value: "updates", label: "Updates", count: updateCount },
-    {
-      value: "not-installed",
-      label: "Not installed",
-      count: plugins.length - installedCount,
-    },
-  ]
+  const detailInstallations = detailEntry
+    ? (installationByEntryId.get(detailEntry.id) ?? [])
+    : []
 
   const allCategories = useMemo(
     () =>
@@ -342,7 +374,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
     [plugins]
   )
 
-  const filtered = useMemo(() => {
+  const nonStatusFiltered = useMemo(() => {
     const query = search.trim().toLowerCase()
     return plugins.filter((entry) => {
       if (query) {
@@ -356,41 +388,81 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
           .toLowerCase()
         if (!haystack.includes(query)) return false
       }
-      const installation = installationByEntryId.get(entry.id)
-      if (statusFilter === "installed" && !installation) return false
-      if (statusFilter === "updates" && !installation?.updateAvailable)
-        return false
-      if (statusFilter === "not-installed" && installation) return false
       if (
         categoryFilter.size > 0 &&
-        !entry.categories.some((c) => categoryFilter.has(c))
+        !entry.categories.some((category) => categoryFilter.has(category))
       )
         return false
       if (
         platformFilter.size > 0 &&
-        !entry.platforms.some((p) => platformFilter.has(p))
+        !entry.platforms.some((platform) => platformFilter.has(platform))
       )
         return false
       return true
     })
-  }, [
-    plugins,
-    search,
-    categoryFilter,
-    platformFilter,
-    statusFilter,
-    installationByEntryId,
-  ])
+  }, [plugins, search, categoryFilter, platformFilter])
+
+  const installedCount = nonStatusFiltered.filter(
+    (entry) => (installationByEntryId.get(entry.id)?.length ?? 0) > 0
+  ).length
+  const updateCount = nonStatusFiltered.filter((entry) =>
+    installationByEntryId
+      .get(entry.id)
+      ?.some((installation) => installation.updateState === "available")
+  ).length
+  const statusOptions: readonly StatusFilterOption[] = [
+    { value: "all", label: "All", count: nonStatusFiltered.length },
+    {
+      value: "installed",
+      label: "Installed",
+      count: inventoryAvailable ? installedCount : undefined,
+      disabled: !inventoryAvailable,
+    },
+    {
+      value: "updates",
+      label: "Updates",
+      count: updateStatusQuery.isSuccess ? updateCount : undefined,
+      disabled: !updateStatusQuery.isSuccess,
+    },
+    {
+      value: "not-installed",
+      label: "Not installed",
+      count: inventoryAvailable
+        ? nonStatusFiltered.length - installedCount
+        : undefined,
+      disabled: !inventoryAvailable,
+    },
+  ]
+  const effectiveStatusFilter = inventoryAvailable ? statusFilter : "all"
+  const filtered = useMemo(
+    () =>
+      nonStatusFiltered.filter((entry) => {
+        const matches = installationByEntryId.get(entry.id) ?? []
+        if (effectiveStatusFilter === "installed") return matches.length > 0
+        if (effectiveStatusFilter === "updates") {
+          return matches.some(
+            (installation) => installation.updateState === "available"
+          )
+        }
+        if (effectiveStatusFilter === "not-installed")
+          return matches.length === 0
+        return true
+      }),
+    [nonStatusFiltered, effectiveStatusFilter, installationByEntryId]
+  )
 
   const sorted = useMemo(
     () =>
       [...filtered].sort((a, b) => {
-        const aInstallation = installationByEntryId.get(a.id)
-        const bInstallation = installationByEntryId.get(b.id)
-        const aRank = aInstallation?.updateAvailable ? 0 : aInstallation ? 1 : 2
-        const bRank = bInstallation?.updateAvailable ? 0 : bInstallation ? 1 : 2
+        const aHasUpdate = installationByEntryId
+          .get(a.id)
+          ?.some((installation) => installation.updateState === "available")
+        const bHasUpdate = installationByEntryId
+          .get(b.id)
+          ?.some((installation) => installation.updateState === "available")
         return (
-          aRank - bRank || (b.repoMeta?.stars ?? 0) - (a.repoMeta?.stars ?? 0)
+          Number(Boolean(bHasUpdate)) - Number(Boolean(aHasUpdate)) ||
+          (b.repoMeta?.stars ?? 0) - (a.repoMeta?.stars ?? 0)
         )
       }),
     [filtered, installationByEntryId]
@@ -447,28 +519,24 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         entry={detailEntry}
         theme={theme}
         compact={layout.compact}
-        installation={detailInstallation}
+        installations={detailInstallations}
+        inventoryAvailable={inventoryAvailable}
         installing={installingId === detailEntry.id}
-        updating={updatingId === detailInstallation?.id}
+        updatingId={updatingId}
         installError={
           installFailure?.entryId === detailEntry.id
             ? installFailure.message
             : null
         }
         updateError={
-          detailEntry && updateFailure?.entryId === detailEntry.id
+          updateFailure?.entryId === detailEntry.id
             ? updateFailure.message
             : null
         }
         onInstall={() => installMutation.mutate(detailEntry)}
-        onUpdate={() => {
-          if (detailInstallation) {
-            updateMutation.mutate({
-              entry: detailEntry,
-              installation: detailInstallation,
-            })
-          }
-        }}
+        onUpdate={(installation) =>
+          updateMutation.mutate({ entry: detailEntry, installation })
+        }
         onOpenGallery={() => setGalleryEntry(detailEntry)}
         onBack={() => setDetailEntry(null)}
       />
@@ -488,7 +556,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       />
       <StatusFilterRow
         options={statusOptions}
-        selected={statusFilter}
+        selected={effectiveStatusFilter}
         theme={theme}
         onSelect={setStatusFilter}
       />
@@ -530,6 +598,14 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       {settingsPending ? (
         <Text style={styles.emptyText}>Loading Paseo Cafe settings…</Text>
       ) : null}
+      {updateStatusQuery.isFetching ? (
+        <Text style={styles.emptyText}>Checking for plugin updates…</Text>
+      ) : null}
+      {updateStatusQuery.isError ? (
+        <Text accessibilityRole="alert" style={styles.emptyText}>
+          Update status is unavailable: {updateStatusQuery.error.message}
+        </Text>
+      ) : null}
       {settings.status === "error" || settings.status === "invalid" ? (
         <Text accessibilityRole="alert" style={styles.emptyText}>
           Paseo Cafe settings need attention, so the default catalog is in use:{" "}
@@ -555,6 +631,12 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
           Catalog generated {directoryQuery.data.fetchedAt.slice(0, 10)}.
         </Text>
       ) : null}
+      {directoryQuery.isSuccess ? (
+        <Text accessibilityLiveRegion="polite" style={styles.emptyText}>
+          Showing {sorted.length} of {nonStatusFiltered.length} matching
+          plugins.
+        </Text>
+      ) : null}
       {directoryQuery.isSuccess && sorted.length === 0 ? (
         <Text style={styles.emptyText}>
           No plugins match the current search and filters.
@@ -568,7 +650,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
           <PluginRow
             entry={item}
             theme={theme}
-            installation={installationByEntryId.get(item.id)}
+            installations={installationByEntryId.get(item.id) ?? []}
             compact={layout.compact}
             onPress={() => setDetailEntry(item)}
           />

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -9,11 +9,13 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 import { Pressable, Text, View } from "react-native"
-import type { DirectoryEntry } from "../shared/directory"
+import type { DirectoryEntry, InstalledPlugin } from "../shared/directory"
 import {
   directoryInstallRpc,
   directoryListRpc,
   directorySettings,
+  directoryUpdateRpc,
+  findInstallation,
 } from "../shared/directory"
 import { PluginDetailPage } from "./PluginDetailPage"
 import { PluginGalleryPage } from "./PluginGalleryPage"
@@ -107,9 +109,87 @@ function FilterRow({
   )
 }
 
+type InstallationStatusFilter =
+  | "all"
+  | "installed"
+  | "updates"
+  | "not-installed"
+
+interface StatusFilterOption {
+  value: InstallationStatusFilter
+  label: string
+  count: number
+}
+
+function StatusFilterRow({
+  options,
+  selected,
+  theme,
+  onSelect,
+}: {
+  options: readonly StatusFilterOption[]
+  selected: InstallationStatusFilter
+  theme: PluginTheme
+  onSelect: (value: InstallationStatusFilter) => void
+}) {
+  const styles = useMemo(
+    () => ({
+      row: {
+        flexDirection: "row" as const,
+        alignItems: "center" as const,
+        gap: 6,
+        flexWrap: "wrap" as const,
+      },
+      label: {
+        color: theme.colors.foregroundMuted,
+        fontSize: 12,
+        marginRight: 2,
+      },
+      chip: (active: boolean) => ({
+        borderRadius: 999,
+        paddingHorizontal: 10,
+        paddingVertical: 5,
+        backgroundColor: active ? theme.colors.accent : theme.colors.surface2,
+      }),
+      chipText: (active: boolean) => ({
+        color: active
+          ? theme.colors.accentForeground
+          : theme.colors.foregroundMuted,
+        fontSize: 12,
+        fontWeight: active ? ("600" as const) : ("400" as const),
+      }),
+    }),
+    [theme]
+  )
+
+  return (
+    <View style={styles.row}>
+      <Text style={styles.label}>Show:</Text>
+      {options.map((option) => {
+        const active = selected === option.value
+        return (
+          <Pressable
+            key={option.value}
+            accessibilityRole="button"
+            accessibilityLabel={`Show ${option.label.toLowerCase()} plugins`}
+            accessibilityState={{ selected: active }}
+            style={styles.chip(active)}
+            onPress={() => onSelect(option.value)}
+          >
+            <Text style={styles.chipText(active)}>
+              {option.label} {option.count}
+            </Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
 export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
   const listDirectory = useRpc(directoryListRpc)
   const installPlugin = useRpc(directoryInstallRpc)
+  const updatePlugin = useRpc(directoryUpdateRpc)
   const settings = useSettings(directorySettings)
   const toast = useToast()
   const queryClient = useQueryClient()
@@ -120,8 +200,15 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
   const [platformFilter, setPlatformFilter] = useState<ReadonlySet<string>>(
     new Set()
   )
+  const [statusFilter, setStatusFilter] =
+    useState<InstallationStatusFilter>("all")
   const [installingId, setInstallingId] = useState<string | null>(null)
   const [installFailure, setInstallFailure] = useState<{
+    entryId: string
+    message: string
+  } | null>(null)
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+  const [updateFailure, setUpdateFailure] = useState<{
     entryId: string
     message: string
   } | null>(null)
@@ -155,6 +242,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       if (result.ok) {
         setInstallFailure(null)
         toast.show(`Installed ${entry.name}`, { variant: "success" })
+        void queryClient.invalidateQueries({ queryKey })
       } else {
         setInstallFailure({ entryId: entry.id, message: result.message })
         toast.error(`Couldn't install ${entry.name}. See details below.`)
@@ -166,6 +254,35 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       toast.error(`Couldn't install ${entry.name}. See details below.`)
     },
     onSettled: () => setInstallingId(null),
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      installation,
+    }: {
+      entry: DirectoryEntry
+      installation: InstalledPlugin
+    }) => {
+      setUpdatingId(installation.id)
+      setUpdateFailure(null)
+      return updatePlugin({ pluginId: installation.id })
+    },
+    onSuccess: (result, { entry }) => {
+      if (result.ok) {
+        setUpdateFailure(null)
+        toast.show(result.message, { variant: "success" })
+        void queryClient.invalidateQueries({ queryKey })
+      } else {
+        setUpdateFailure({ entryId: entry.id, message: result.message })
+        toast.error(`Couldn't update ${entry.name}. See details below.`)
+      }
+    },
+    onError: (error, { entry }) => {
+      const message = error instanceof Error ? error.message : "Update failed"
+      setUpdateFailure({ entryId: entry.id, message })
+      toast.error(`Couldn't update ${entry.name}. See details below.`)
+    },
+    onSettled: () => setUpdatingId(null),
   })
 
   const refreshMutation = useMutation({
@@ -185,6 +302,34 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
   })
 
   const plugins = directoryQuery.data?.plugins ?? []
+  const installations = directoryQuery.data?.installations ?? []
+  const installationByEntryId = useMemo(
+    () =>
+      new Map(
+        plugins.flatMap((entry) => {
+          const installation = findInstallation(entry, installations)
+          return installation ? [[entry.id, installation] as const] : []
+        })
+      ),
+    [plugins, installations]
+  )
+  const detailInstallation = detailEntry
+    ? installationByEntryId.get(detailEntry.id)
+    : undefined
+  const installedCount = installationByEntryId.size
+  const updateCount = Array.from(installationByEntryId.values()).filter(
+    (installation) => installation.updateAvailable
+  ).length
+  const statusOptions: readonly StatusFilterOption[] = [
+    { value: "all", label: "All", count: plugins.length },
+    { value: "installed", label: "Installed", count: installedCount },
+    { value: "updates", label: "Updates", count: updateCount },
+    {
+      value: "not-installed",
+      label: "Not installed",
+      count: plugins.length - installedCount,
+    },
+  ]
 
   const allCategories = useMemo(
     () =>
@@ -211,6 +356,11 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
           .toLowerCase()
         if (!haystack.includes(query)) return false
       }
+      const installation = installationByEntryId.get(entry.id)
+      if (statusFilter === "installed" && !installation) return false
+      if (statusFilter === "updates" && !installation?.updateAvailable)
+        return false
+      if (statusFilter === "not-installed" && installation) return false
       if (
         categoryFilter.size > 0 &&
         !entry.categories.some((c) => categoryFilter.has(c))
@@ -223,14 +373,27 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         return false
       return true
     })
-  }, [plugins, search, categoryFilter, platformFilter])
+  }, [
+    plugins,
+    search,
+    categoryFilter,
+    platformFilter,
+    statusFilter,
+    installationByEntryId,
+  ])
 
   const sorted = useMemo(
     () =>
-      [...filtered].sort(
-        (a, b) => (b.repoMeta?.stars ?? 0) - (a.repoMeta?.stars ?? 0)
-      ),
-    [filtered]
+      [...filtered].sort((a, b) => {
+        const aInstallation = installationByEntryId.get(a.id)
+        const bInstallation = installationByEntryId.get(b.id)
+        const aRank = aInstallation?.updateAvailable ? 0 : aInstallation ? 1 : 2
+        const bRank = bInstallation?.updateAvailable ? 0 : bInstallation ? 1 : 2
+        return (
+          aRank - bRank || (b.repoMeta?.stars ?? 0) - (a.repoMeta?.stars ?? 0)
+        )
+      }),
+    [filtered, installationByEntryId]
   )
 
   const styles = useMemo(
@@ -284,13 +447,28 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         entry={detailEntry}
         theme={theme}
         compact={layout.compact}
+        installation={detailInstallation}
         installing={installingId === detailEntry.id}
+        updating={updatingId === detailInstallation?.id}
         installError={
           installFailure?.entryId === detailEntry.id
             ? installFailure.message
             : null
         }
+        updateError={
+          detailEntry && updateFailure?.entryId === detailEntry.id
+            ? updateFailure.message
+            : null
+        }
         onInstall={() => installMutation.mutate(detailEntry)}
+        onUpdate={() => {
+          if (detailInstallation) {
+            updateMutation.mutate({
+              entry: detailEntry,
+              installation: detailInstallation,
+            })
+          }
+        }}
         onOpenGallery={() => setGalleryEntry(detailEntry)}
         onBack={() => setDetailEntry(null)}
       />
@@ -307,6 +485,12 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         onChangeText={setSearch}
         style={styles.searchInput}
         placeholderTextColor={theme.colors.foregroundMuted}
+      />
+      <StatusFilterRow
+        options={statusOptions}
+        selected={statusFilter}
+        theme={theme}
+        onSelect={setStatusFilter}
       />
       <View style={styles.filtersBlock}>
         <FilterRow
@@ -352,6 +536,12 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
           {settings.error}
         </Text>
       ) : null}
+      {directoryQuery.data?.installationError ? (
+        <Text accessibilityRole="alert" style={styles.emptyText}>
+          Couldn't check installed plugins:{" "}
+          {directoryQuery.data.installationError}
+        </Text>
+      ) : null}
       {directoryQuery.isPending && !settingsPending ? (
         <Text style={styles.emptyText}>Loading plugins…</Text>
       ) : null}
@@ -378,6 +568,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
           <PluginRow
             entry={item}
             theme={theme}
+            installation={installationByEntryId.get(item.id)}
             compact={layout.compact}
             onPress={() => setDetailEntry(item)}
           />

--- a/plugin/client/PluginDetailPage.tsx
+++ b/plugin/client/PluginDetailPage.tsx
@@ -23,13 +23,14 @@ interface PluginDetailPageProps {
   entry: DirectoryEntry
   theme: PluginTheme
   compact: boolean
-  installation?: InstalledPlugin
+  installations: readonly InstalledPlugin[]
+  inventoryAvailable: boolean
   installing: boolean
-  updating: boolean
+  updatingId: string | null
   installError: string | null
   updateError: string | null
   onInstall: () => void
-  onUpdate: () => void
+  onUpdate: (installation: InstalledPlugin) => void
   onOpenGallery: () => void
   onBack: () => void
 }
@@ -39,13 +40,23 @@ function formatDate(iso: string | undefined): string | undefined {
   return iso ? iso.slice(0, 10) : undefined
 }
 
+function installationStateLabel(installation: InstalledPlugin): string {
+  if (installation.source === "directory") return "Installed locally"
+  if (installation.updateState === "available") return "Update available"
+  if (installation.updateState === "current") return "Up to date"
+  if (installation.updateState === "pinned") return "Pinned"
+  if (installation.updateState === "diverged") return "Source diverged"
+  return "Update status unavailable"
+}
+
 export function PluginDetailPage({
   entry,
   theme,
   compact,
-  installation,
+  installations,
+  inventoryAvailable,
   installing,
-  updating,
+  updatingId,
   installError,
   updateError,
   onInstall,
@@ -55,6 +66,8 @@ export function PluginDetailPage({
 }: PluginDetailPageProps) {
   const toast = useToast()
   const [confirmingInstall, setConfirmingInstall] = useState(false)
+  const [confirmingUpdate, setConfirmingUpdate] =
+    useState<InstalledPlugin | null>(null)
   const [showFullActionError, setShowFullActionError] = useState(false)
 
   const styles = useMemo(
@@ -267,7 +280,7 @@ export function PluginDetailPage({
         paddingVertical: 10,
         borderRadius: 8,
         backgroundColor: theme.colors.accent,
-        opacity: installing || updating ? 0.6 : 1,
+        opacity: installing || updatingId !== null ? 0.6 : 1,
       },
       buttonText: {
         color: theme.colors.accentForeground,
@@ -282,6 +295,20 @@ export function PluginDetailPage({
         borderColor: theme.colors.border,
       },
       secondaryButtonText: { color: theme.colors.foreground, fontSize: 14 },
+      installationList: { gap: 8 },
+      installationCard: {
+        gap: 8,
+        borderWidth: 1,
+        borderColor: theme.colors.border,
+        borderRadius: 8,
+        padding: 10,
+        backgroundColor: theme.colors.surface1,
+      },
+      installationTitle: {
+        color: theme.colors.foreground,
+        fontSize: 13,
+        fontWeight: "600" as const,
+      },
       healthGrid: {
         flexDirection: "row" as const,
         flexWrap: "wrap" as const,
@@ -307,7 +334,7 @@ export function PluginDetailPage({
         lineHeight: 19,
       },
     }),
-    [theme, compact, installing, updating]
+    [theme, compact, installing, updatingId]
   )
 
   const command = getInstallCommand(entry)
@@ -327,18 +354,8 @@ export function PluginDetailPage({
   const installable =
     isValidRepo(entry.repo) &&
     (entry.path === undefined || isValidInstallPath(entry.path))
-  const actionPending = installing || updating
-  const canUpdate =
-    installation?.source === "git" && installation.updateAvailable
-  const actionEnabled = installation ? canUpdate : installable
-  const primaryActionLabel = updating
-    ? "Updating…"
-    : installing
-      ? "Installing…"
-      : installation
-        ? "Update"
-        : "Install"
-  const actionError = installation ? updateError : installError
+  const actionPending = installing || updatingId !== null
+  const actionError = installations.length > 0 ? updateError : installError
   // The toggle and the clamp share one condition: a short error is never
   // clamped, so wrapping on a narrow screen cannot hide text with no way back.
   const actionErrorIsLong =
@@ -556,34 +573,94 @@ export function PluginDetailPage({
           ) : null}
         </View>
 
-        {installation ? (
-          <Text style={styles.metaText}>
-            {installation.source === "directory"
-              ? "Installed locally"
-              : installation.updateAvailable
-                ? "Update available"
-                : "Up to date"}
-            {` · ${installation.id}`}
-            {installation.commit
-              ? ` at ${installation.commit.slice(0, 12)}`
-              : ""}
-            .
-          </Text>
+        {!inventoryAvailable ? (
+          <View accessibilityRole="alert" style={styles.errorBox}>
+            <Text style={styles.errorText}>
+              Installed plugin status unavailable
+            </Text>
+            <Text style={styles.alertBody}>
+              Install and update actions are disabled until Paseo can read this
+              host's plugin inventory.
+            </Text>
+          </View>
+        ) : null}
+
+        {installations.length > 0 ? (
+          <View style={styles.installationList}>
+            <Text style={styles.label}>Installations</Text>
+            {installations.map((installation) => {
+              const updateCommand = `paseo plugin update ${installation.id}`
+              return (
+                <View key={installation.id} style={styles.installationCard}>
+                  <Text style={styles.installationTitle}>
+                    {installationStateLabel(installation)} · {installation.id}
+                  </Text>
+                  <Text selectable style={styles.metaText}>
+                    {installation.remote ?? installation.path}
+                    {installation.ref ? ` · ${installation.ref}` : ""}
+                    {installation.commit
+                      ? ` · ${installation.commit.slice(0, 12)}`
+                      : ""}
+                    {installation.latestCommit
+                      ? ` → ${installation.latestCommit.slice(0, 12)}`
+                      : ""}
+                  </Text>
+                  {installation.updateError ? (
+                    <Text style={styles.errorText}>
+                      {installation.updateError}
+                    </Text>
+                  ) : null}
+                  {installation.updateState === "available" ? (
+                    entry.id === "paseo-cafe" ? (
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={`Copy update command for ${installation.id}`}
+                        style={styles.secondaryButton}
+                        onPress={async () => {
+                          await copyText(updateCommand)
+                          toast.show("Copied update command")
+                        }}
+                      >
+                        <Text style={styles.secondaryButtonText}>
+                          Copy update command
+                        </Text>
+                      </Pressable>
+                    ) : (
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={`Update ${entry.name} installation ${installation.id}`}
+                        accessibilityState={{ disabled: actionPending }}
+                        style={styles.button}
+                        disabled={actionPending}
+                        onPress={() => setConfirmingUpdate(installation)}
+                      >
+                        <Text style={styles.buttonText}>
+                          {updatingId === installation.id
+                            ? "Updating…"
+                            : "Update"}
+                        </Text>
+                      </Pressable>
+                    )
+                  ) : null}
+                </View>
+              )
+            })}
+          </View>
         ) : null}
 
         <View style={styles.actionsRow}>
-          {!installation || canUpdate ? (
+          {inventoryAvailable && installations.length === 0 ? (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel={`${installation ? "Update" : "Install"} ${entry.name}`}
-              accessibilityState={{ disabled: actionPending || !actionEnabled }}
-              style={[styles.button, !actionEnabled ? { opacity: 0.5 } : null]}
-              disabled={actionPending || !actionEnabled}
-              onPress={
-                installation ? onUpdate : () => setConfirmingInstall(true)
-              }
+              accessibilityLabel={`Install ${entry.name}`}
+              accessibilityState={{ disabled: actionPending || !installable }}
+              style={[styles.button, !installable ? { opacity: 0.5 } : null]}
+              disabled={actionPending || !installable}
+              onPress={() => setConfirmingInstall(true)}
             >
-              <Text style={styles.buttonText}>{primaryActionLabel}</Text>
+              <Text style={styles.buttonText}>
+                {installing ? "Installing…" : "Install"}
+              </Text>
             </Pressable>
           ) : null}
           <Pressable
@@ -596,7 +673,7 @@ export function PluginDetailPage({
           </Pressable>
         </View>
 
-        {!installation && !installable ? (
+        {inventoryAvailable && installations.length === 0 && !installable ? (
           <View accessibilityRole="alert" style={styles.errorBox}>
             <Text style={styles.errorText}>
               This listing has an invalid repository or plugin subpath and
@@ -608,7 +685,9 @@ export function PluginDetailPage({
         {actionError ? (
           <View accessibilityRole="alert" style={styles.errorBox}>
             <Text style={styles.errorText}>
-              {installation ? "Update failed" : "Installation failed"}
+              {installations.length > 0
+                ? "Update failed"
+                : "Installation failed"}
             </Text>
             <Text
               numberOfLines={
@@ -740,6 +819,56 @@ export function PluginDetailPage({
               }}
             >
               <Text style={styles.buttonText}>Install</Text>
+            </Pressable>
+          </View>
+        </Modal.Content>
+      </Modal>
+      <Modal
+        title={`Update ${entry.name}?`}
+        icon={<Icon name="RefreshCw" size={18} color={theme.colors.accent} />}
+        open={confirmingUpdate !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmingUpdate(null)
+        }}
+      >
+        <Modal.Content contentContainerStyle={styles.modalBody}>
+          <Text style={styles.modalTitle}>{confirmingUpdate?.id}</Text>
+          <Text selectable style={styles.modalText}>
+            {confirmingUpdate?.remote}
+            {confirmingUpdate?.ref ? ` · ${confirmingUpdate.ref}` : ""}
+          </Text>
+          <Text selectable style={styles.modalText}>
+            {confirmingUpdate?.commit?.slice(0, 12)} →{" "}
+            {confirmingUpdate?.latestCommit?.slice(0, 12)}
+          </Text>
+          <Text style={styles.modalText}>
+            Updating replaces trusted, unsandboxed plugin code on this Paseo
+            host. Review the source before continuing.
+          </Text>
+          <View style={styles.actionsRow}>
+            <Pressable
+              accessibilityRole="link"
+              style={styles.secondaryButton}
+              onPress={() => openExternal(entry.url)}
+            >
+              <Text style={styles.secondaryButtonText}>View repo</Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              style={styles.secondaryButton}
+              onPress={() => setConfirmingUpdate(null)}
+            >
+              <Text style={styles.secondaryButtonText}>Cancel</Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              style={styles.button}
+              onPress={() => {
+                if (confirmingUpdate) onUpdate(confirmingUpdate)
+                setConfirmingUpdate(null)
+              }}
+            >
+              <Text style={styles.buttonText}>Update</Text>
             </Pressable>
           </View>
         </Modal.Content>

--- a/plugin/client/PluginDetailPage.tsx
+++ b/plugin/client/PluginDetailPage.tsx
@@ -8,7 +8,7 @@ import {
 } from "@getpaseo/plugin/client/react-native"
 import { useMemo, useState } from "react"
 import { Image, Pressable, Text, View } from "react-native"
-import type { DirectoryEntry } from "../shared/directory"
+import type { DirectoryEntry, InstalledPlugin } from "../shared/directory"
 import {
   getInstallCommand,
   getSiteUrl,
@@ -23,9 +23,13 @@ interface PluginDetailPageProps {
   entry: DirectoryEntry
   theme: PluginTheme
   compact: boolean
+  installation?: InstalledPlugin
   installing: boolean
+  updating: boolean
   installError: string | null
+  updateError: string | null
   onInstall: () => void
+  onUpdate: () => void
   onOpenGallery: () => void
   onBack: () => void
 }
@@ -39,15 +43,19 @@ export function PluginDetailPage({
   entry,
   theme,
   compact,
+  installation,
   installing,
+  updating,
   installError,
+  updateError,
   onInstall,
+  onUpdate,
   onOpenGallery,
   onBack,
 }: PluginDetailPageProps) {
   const toast = useToast()
   const [confirmingInstall, setConfirmingInstall] = useState(false)
-  const [showFullInstallError, setShowFullInstallError] = useState(false)
+  const [showFullActionError, setShowFullActionError] = useState(false)
 
   const styles = useMemo(
     () => ({
@@ -259,7 +267,7 @@ export function PluginDetailPage({
         paddingVertical: 10,
         borderRadius: 8,
         backgroundColor: theme.colors.accent,
-        opacity: installing ? 0.6 : 1,
+        opacity: installing || updating ? 0.6 : 1,
       },
       buttonText: {
         color: theme.colors.accentForeground,
@@ -299,7 +307,7 @@ export function PluginDetailPage({
         lineHeight: 19,
       },
     }),
-    [theme, compact, installing]
+    [theme, compact, installing, updating]
   )
 
   const command = getInstallCommand(entry)
@@ -319,11 +327,23 @@ export function PluginDetailPage({
   const installable =
     isValidRepo(entry.repo) &&
     (entry.path === undefined || isValidInstallPath(entry.path))
+  const actionPending = installing || updating
+  const canUpdate =
+    installation?.source === "git" && installation.updateAvailable
+  const actionEnabled = installation ? canUpdate : installable
+  const primaryActionLabel = updating
+    ? "Updating…"
+    : installing
+      ? "Installing…"
+      : installation
+        ? "Update"
+        : "Install"
+  const actionError = installation ? updateError : installError
   // The toggle and the clamp share one condition: a short error is never
   // clamped, so wrapping on a narrow screen cannot hide text with no way back.
-  const installErrorIsLong =
-    installError !== null &&
-    (installError.length > 240 || installError.split("\n").length > 6)
+  const actionErrorIsLong =
+    actionError !== null &&
+    (actionError.length > 240 || actionError.split("\n").length > 6)
 
   return (
     <View style={styles.screen}>
@@ -536,19 +556,36 @@ export function PluginDetailPage({
           ) : null}
         </View>
 
+        {installation ? (
+          <Text style={styles.metaText}>
+            {installation.source === "directory"
+              ? "Installed locally"
+              : installation.updateAvailable
+                ? "Update available"
+                : "Up to date"}
+            {` · ${installation.id}`}
+            {installation.commit
+              ? ` at ${installation.commit.slice(0, 12)}`
+              : ""}
+            .
+          </Text>
+        ) : null}
+
         <View style={styles.actionsRow}>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={`Install ${entry.name}`}
-            accessibilityState={{ disabled: installing || !installable }}
-            style={[styles.button, !installable ? { opacity: 0.5 } : null]}
-            disabled={installing || !installable}
-            onPress={() => setConfirmingInstall(true)}
-          >
-            <Text style={styles.buttonText}>
-              {installing ? "Installing…" : "Install"}
-            </Text>
-          </Pressable>
+          {!installation || canUpdate ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`${installation ? "Update" : "Install"} ${entry.name}`}
+              accessibilityState={{ disabled: actionPending || !actionEnabled }}
+              style={[styles.button, !actionEnabled ? { opacity: 0.5 } : null]}
+              disabled={actionPending || !actionEnabled}
+              onPress={
+                installation ? onUpdate : () => setConfirmingInstall(true)
+              }
+            >
+              <Text style={styles.buttonText}>{primaryActionLabel}</Text>
+            </Pressable>
+          ) : null}
           <Pressable
             accessibilityRole="link"
             accessibilityLabel={`Open ${entry.name} on GitHub`}
@@ -559,7 +596,7 @@ export function PluginDetailPage({
           </Pressable>
         </View>
 
-        {!installable ? (
+        {!installation && !installable ? (
           <View accessibilityRole="alert" style={styles.errorBox}>
             <Text style={styles.errorText}>
               This listing has an invalid repository or plugin subpath and
@@ -568,46 +605,48 @@ export function PluginDetailPage({
           </View>
         ) : null}
 
-        {installError ? (
+        {actionError ? (
           <View accessibilityRole="alert" style={styles.errorBox}>
-            <Text style={styles.errorText}>Installation failed</Text>
+            <Text style={styles.errorText}>
+              {installation ? "Update failed" : "Installation failed"}
+            </Text>
             <Text
               numberOfLines={
-                installErrorIsLong && !showFullInstallError ? 6 : undefined
+                actionErrorIsLong && !showFullActionError ? 6 : undefined
               }
               selectable
               style={styles.errorDetails}
             >
-              {installError}
+              {actionError}
             </Text>
             <View style={styles.errorActions}>
-              {installErrorIsLong ? (
+              {actionErrorIsLong ? (
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel={
-                    showFullInstallError
-                      ? "Show less installation error output"
-                      : "View full installation error output"
+                    showFullActionError
+                      ? "Show less action error output"
+                      : "View full action error output"
                   }
-                  onPress={() => setShowFullInstallError((current) => !current)}
+                  onPress={() => setShowFullActionError((current) => !current)}
                   style={styles.errorAction}
                 >
                   <Icon
-                    name={showFullInstallError ? "ChevronUp" : "ChevronDown"}
+                    name={showFullActionError ? "ChevronUp" : "ChevronDown"}
                     size={14}
                     color={theme.colors.accent}
                   />
                   <Text style={styles.errorActionText}>
-                    {showFullInstallError ? "Show less" : "View more…"}
+                    {showFullActionError ? "Show less" : "View more…"}
                   </Text>
                 </Pressable>
               ) : null}
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="Copy installation error output"
+                accessibilityLabel="Copy action error output"
                 onPress={async () => {
-                  await copyText(installError)
-                  toast.show("Copied installation error output")
+                  await copyText(actionError)
+                  toast.show("Copied action error output")
                 }}
                 style={styles.errorAction}
               >

--- a/plugin/client/PluginRow.tsx
+++ b/plugin/client/PluginRow.tsx
@@ -8,7 +8,7 @@ interface PluginRowProps {
   entry: DirectoryEntry
   theme: PluginTheme
   compact: boolean
-  installation?: InstalledPlugin
+  installations: readonly InstalledPlugin[]
   onPress: () => void
 }
 
@@ -19,7 +19,7 @@ export function PluginRow({
   entry,
   theme,
   compact,
-  installation,
+  installations,
   onPress,
 }: PluginRowProps) {
   const styles = useMemo(
@@ -36,6 +36,7 @@ export function PluginRow({
         flexDirection: "row" as const,
         alignItems: "center" as const,
         gap: 8,
+        flexWrap: "wrap" as const,
       },
       starsRow: {
         flexDirection: "row" as const,
@@ -95,10 +96,24 @@ export function PluginRow({
   const tags = [...entry.categories, ...entry.platforms]
   const hasTagsRow = tags.length > 0 || !!entry.paseoVersionRequirement
 
+  const updateCount = installations.filter(
+    (installation) => installation.updateState === "available"
+  ).length
+  const statusLabel =
+    updateCount > 0
+      ? updateCount === 1
+        ? "Update available"
+        : `${updateCount} updates available`
+      : installations.length > 0
+        ? installations.length === 1
+          ? "Installed"
+          : `${installations.length} installations`
+        : undefined
+
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={`View details for ${entry.name}`}
+      accessibilityLabel={`View details for ${entry.name}${statusLabel ? `, ${statusLabel}` : ""}`}
       style={styles.row}
       onPress={onPress}
     >
@@ -111,10 +126,10 @@ export function PluginRow({
           />
         ) : null}
         <Text style={styles.name}>{entry.name}</Text>
-        {installation ? (
+        {statusLabel ? (
           <View style={styles.statusBadge}>
-            <Text style={styles.statusText(installation.updateAvailable)}>
-              {installation.updateAvailable ? "Update available" : "Installed"}
+            <Text style={styles.statusText(updateCount > 0)}>
+              {statusLabel}
             </Text>
           </View>
         ) : null}

--- a/plugin/client/PluginRow.tsx
+++ b/plugin/client/PluginRow.tsx
@@ -2,19 +2,26 @@ import type { PluginTheme } from "@getpaseo/plugin"
 import { Icon } from "@getpaseo/plugin/client/react-native"
 import { useMemo } from "react"
 import { Image, Pressable, Text, View } from "react-native"
-import type { DirectoryEntry } from "../shared/directory"
+import type { DirectoryEntry, InstalledPlugin } from "../shared/directory"
 
 interface PluginRowProps {
   entry: DirectoryEntry
   theme: PluginTheme
   compact: boolean
+  installation?: InstalledPlugin
   onPress: () => void
 }
 
 // Deliberately no per-row Install button: with the whole card opening the
 // detail page (see onPress below), a nested button here fights the card's
 // own press target. Install lives on the detail page instead.
-export function PluginRow({ entry, theme, compact, onPress }: PluginRowProps) {
+export function PluginRow({
+  entry,
+  theme,
+  compact,
+  installation,
+  onPress,
+}: PluginRowProps) {
   const styles = useMemo(
     () => ({
       row: {
@@ -43,6 +50,19 @@ export function PluginRow({ entry, theme, compact, onPress }: PluginRowProps) {
         fontWeight: "600" as const,
         flexShrink: 1,
       },
+      statusBadge: {
+        borderRadius: 999,
+        paddingHorizontal: 8,
+        paddingVertical: 2,
+        backgroundColor: theme.colors.surface2,
+      },
+      statusText: (updateAvailable: boolean) => ({
+        color: updateAvailable
+          ? theme.colors.statusWarning
+          : theme.colors.statusSuccess,
+        fontSize: 11,
+        fontWeight: "600" as const,
+      }),
       meta: { color: theme.colors.foregroundMuted, fontSize: 12 },
       description: { color: theme.colors.foregroundMuted, fontSize: 13 },
       tagsRow: {
@@ -91,6 +111,13 @@ export function PluginRow({ entry, theme, compact, onPress }: PluginRowProps) {
           />
         ) : null}
         <Text style={styles.name}>{entry.name}</Text>
+        {installation ? (
+          <View style={styles.statusBadge}>
+            <Text style={styles.statusText(installation.updateAvailable)}>
+              {installation.updateAvailable ? "Update available" : "Installed"}
+            </Text>
+          </View>
+        ) : null}
         {entry.repoMeta?.stars !== undefined ? (
           <View style={styles.starsRow}>
             <Icon name="Star" size={12} color={theme.colors.foregroundMuted} />

--- a/plugin/index.server.ts
+++ b/plugin/index.server.ts
@@ -2,6 +2,7 @@ import type { PluginServerContext } from "@getpaseo/plugin/server"
 import {
   installDirectoryPlugin,
   listDirectory,
+  listDirectoryUpdateStatus,
   searchDirectory,
   updateDirectoryPlugin,
 } from "./server/directory"
@@ -11,11 +12,15 @@ import {
   directorySearchRpc,
   directorySettings,
   directoryUpdateRpc,
+  directoryUpdateStatusRpc,
 } from "./shared/directory"
 
 export default function contribute(server: PluginServerContext) {
   server.registerSettings(directorySettings)
   server.handle(directoryListRpc, (input) => listDirectory(input))
+  server.handle(directoryUpdateStatusRpc, (input) =>
+    listDirectoryUpdateStatus(input)
+  )
   server.handle(directorySearchRpc, (input) => searchDirectory(input))
   server.handle(directoryInstallRpc, (input) => installDirectoryPlugin(input))
   server.handle(directoryUpdateRpc, (input) => updateDirectoryPlugin(input))

--- a/plugin/index.server.ts
+++ b/plugin/index.server.ts
@@ -3,12 +3,14 @@ import {
   installDirectoryPlugin,
   listDirectory,
   searchDirectory,
+  updateDirectoryPlugin,
 } from "./server/directory"
 import {
   directoryInstallRpc,
   directoryListRpc,
   directorySearchRpc,
   directorySettings,
+  directoryUpdateRpc,
 } from "./shared/directory"
 
 export default function contribute(server: PluginServerContext) {
@@ -16,5 +18,6 @@ export default function contribute(server: PluginServerContext) {
   server.handle(directoryListRpc, (input) => listDirectory(input))
   server.handle(directorySearchRpc, (input) => searchDirectory(input))
   server.handle(directoryInstallRpc, (input) => installDirectoryPlugin(input))
+  server.handle(directoryUpdateRpc, (input) => updateDirectoryPlugin(input))
   return () => {}
 }

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -197,9 +197,9 @@ describe("catalog installation matching", () => {
       id: "review",
     })
 
-    expect(findInstallations({ id: "review", repo: "other/repo" }, [installation])).toEqual([
-      installation,
-    ])
+    expect(
+      findInstallations({ id: "review", repo: "other/repo" }, [installation])
+    ).toEqual([installation])
   })
 
   it("defaults missing update state to unknown for mixed bundle versions", () => {
@@ -322,7 +322,7 @@ describe("Paseo CLI invocation", () => {
       "/d",
       "/s",
       "/c",
-      '\"paseo\" \"plugin\" \"update\" \"review\" \"--json\"',
+      '"paseo" "plugin" "update" "review" "--json"',
     ])
   })
 
@@ -352,4 +352,4 @@ describe("bounded update checks", () => {
     expect(maximum).toBe(2)
     expect(results).toEqual([2, 4, 6, 8, 10, 12])
   })
-}
+})

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
+import type { InstalledPlugin } from "../shared/directory"
+import { findInstallations, installedPluginSchema } from "../shared/directory"
 import {
+  buildPaseoInvocation,
+  inspectUpdateStatus,
   installDirectoryPlugin,
   listDirectory,
+  mapWithConcurrency,
   searchDirectory,
+  updateDirectoryPlugin,
 } from "./directory"
 
 const originalFetch = globalThis.fetch
@@ -18,6 +24,26 @@ function plugin(overrides: Record<string, unknown> = {}) {
     platforms: ["linux"],
     caveats: [],
     repoMeta: { stars: 10 },
+    ...overrides,
+  }
+}
+
+const CURRENT = "a".repeat(40)
+const LATEST = "b".repeat(40)
+
+function gitInstallation(
+  overrides: Partial<InstalledPlugin> = {}
+): InstalledPlugin {
+  return {
+    id: "review",
+    path: "/tmp/version/checkout/plugins/review",
+    enabled: true,
+    status: "running",
+    source: "git",
+    remote: "https://github.com/acme/plugins.git",
+    ref: "main",
+    commit: CURRENT,
+    updateState: "unknown",
     ...overrides,
   }
 }
@@ -122,3 +148,208 @@ describe("installDirectoryPlugin", () => {
     })
   })
 })
+
+describe("catalog installation matching", () => {
+  it("does not bind an equal runtime ID to a different Git source", () => {
+    const matches = findInstallations(
+      { id: "review", repo: "trusted/review" },
+      [gitInstallation({ remote: "https://github.com/attacker/fork.git" })]
+    )
+
+    expect(matches).toEqual([])
+  })
+
+  it("returns every alias for the same repository and plugin path", () => {
+    const matches = findInstallations(
+      { id: "review", repo: "acme/plugins", path: "plugins/review" },
+      [
+        gitInstallation({ id: "review" }),
+        gitInstallation({
+          id: "review-canary",
+          remote: "git://github.com/acme/plugins.git",
+        }),
+        gitInstallation({
+          id: "other",
+          path: "/tmp/version/checkout/plugins/other",
+        }),
+      ]
+    )
+
+    expect(matches.map((installation) => installation.id)).toEqual([
+      "review",
+      "review-canary",
+    ])
+  })
+
+  it("normalizes root plugin paths", () => {
+    const matches = findInstallations(
+      { id: "review", repo: "acme/plugins", path: "." },
+      [gitInstallation({ id: "alias", path: "/tmp/version/checkout" })]
+    )
+
+    expect(matches).toHaveLength(1)
+  })
+
+  it("matches directory installations only by their runtime ID", () => {
+    const installation = gitInstallation({
+      source: "directory",
+      remote: undefined,
+      id: "review",
+    })
+
+    expect(findInstallations({ id: "review", repo: "other/repo" }, [installation])).toEqual([
+      installation,
+    ])
+  })
+
+  it("defaults missing update state to unknown for mixed bundle versions", () => {
+    const parsed = installedPluginSchema.parse({
+      id: "review",
+      path: "/tmp/review",
+      enabled: true,
+      status: "running",
+    })
+
+    expect(parsed.updateState).toBe("unknown")
+  })
+})
+
+describe("update status classification", () => {
+  it("keeps tags and commits pinned when no tracked branch existed at install", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 1 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+
+    const result = await inspectUpdateStatus(
+      gitInstallation({ ref: "v1.0.0" }),
+      runGit
+    )
+
+    expect(result.updateState).toBe("pinned")
+    expect(runGit).toHaveBeenCalledTimes(2)
+  })
+
+  it("reports a deleted tracked branch as unavailable rather than pinned", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 1 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 1 })
+
+    const result = await inspectUpdateStatus(gitInstallation(), runGit)
+
+    expect(result.updateState).toBe("unknown")
+    expect(result.updateError).toContain("Tracked branch is unavailable")
+  })
+
+  it("reports current only after fetching and resolving the tracked branch", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: `${CURRENT}\n`, exitCode: 0 })
+
+    const result = await inspectUpdateStatus(gitInstallation(), runGit)
+
+    expect(result.updateState).toBe("current")
+    expect(result.latestCommit).toBe(CURRENT)
+  })
+
+  it("offers an update only when the installed commit is an ancestor", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: `${LATEST}\n`, exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+
+    const result = await inspectUpdateStatus(gitInstallation(), runGit)
+
+    expect(result.updateState).toBe("available")
+    expect(result.latestCommit).toBe(LATEST)
+  })
+
+  it("does not offer an update for a diverged source", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: `${LATEST}\n`, exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 1 })
+
+    const result = await inspectUpdateStatus(gitInstallation(), runGit)
+
+    expect(result.updateState).toBe("diverged")
+  })
+
+  it("preserves an explicit unknown state when the remote check fails", async () => {
+    const result = await inspectUpdateStatus(gitInstallation(), async () => {
+      throw new Error("offline")
+    })
+
+    expect(result.updateState).toBe("unknown")
+    expect(result.updateError).toContain("offline")
+  })
+})
+
+describe("update target validation", () => {
+  it("refuses to update Paseo Cafe from its own running process", async () => {
+    const result = await updateDirectoryPlugin({
+      pluginId: "paseo-cafe",
+      entry: { id: "paseo-cafe", repo: "paseo-cafe/paseo-cafe" },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain("outside the running plugin")
+  })
+})
+
+describe("Paseo CLI invocation", () => {
+  it("uses direct argv execution on Unix", () => {
+    expect(buildPaseoInvocation(["plugin", "ls", "--json"], "linux")).toEqual({
+      executable: "paseo",
+      args: ["plugin", "ls", "--json"],
+    })
+  })
+
+  it("quotes the npm command shim invocation on Windows", () => {
+    const invocation = buildPaseoInvocation(
+      ["plugin", "update", "review", "--json"],
+      "win32"
+    )
+
+    expect(invocation.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '\"paseo\" \"plugin\" \"update\" \"review\" \"--json\"',
+    ])
+  })
+
+  it("rejects Windows command metacharacters", () => {
+    expect(() =>
+      buildPaseoInvocation(["plugin", "update", "review&calc"], "win32")
+    ).toThrow("unsupported Windows shell characters")
+  })
+})
+
+describe("bounded update checks", () => {
+  it("never runs more than the configured number of workers", async () => {
+    let active = 0
+    let maximum = 0
+    const results = await mapWithConcurrency(
+      [1, 2, 3, 4, 5, 6],
+      2,
+      async (value) => {
+        active += 1
+        maximum = Math.max(maximum, active)
+        await Promise.resolve()
+        active -= 1
+        return value * 2
+      }
+    )
+
+    expect(maximum).toBe(2)
+    expect(results).toEqual([2, 4, 6, 8, 10, 12])
+  })
+}

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -7,13 +7,16 @@ import type {
   directoryInstallRpc,
   directoryListRpc,
   directorySearchRpc,
+  directoryUpdateRpc,
 } from "../shared/directory"
 import {
   DEFAULT_DIRECTORY_URL,
   directoryEntrySchema,
+  findInstallation,
   getInstallCommand,
   getSiteUrl,
   HEALTH_LABELS,
+  installedPluginSchema,
   isValidInstallPath,
   isValidRepo,
   stripHtml,
@@ -31,6 +34,89 @@ const directoryResponseSchema = z.object({
   plugins: z.array(directoryEntrySchema),
   generatedAt: z.iso.datetime({ offset: true, local: true }).optional(),
 })
+const pluginUpdateResponseSchema = z.array(
+  z.object({
+    id: z.string(),
+    updated: z.boolean(),
+    previousCommit: z.string(),
+    currentCommit: z.string(),
+    commits: z.number().int().nonnegative(),
+  })
+)
+const TRACKED_BRANCH_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/
+
+async function addUpdateAvailability(
+  plugins: readonly DirectoryEntry[],
+  installations: readonly z.infer<typeof installedPluginSchema>[]
+) {
+  return Promise.all(
+    installations.map(async (installation) => {
+      if (
+        installation.source !== "git" ||
+        !installation.ref ||
+        !installation.commit ||
+        !TRACKED_BRANCH_PATTERN.test(installation.ref) ||
+        installation.ref.includes("..")
+      ) {
+        return installation
+      }
+      const entry = plugins.find(
+        (candidate) => findInstallation(candidate, [installation]) !== undefined
+      )
+      if (!entry || !isValidRepo(entry.repo)) return installation
+      try {
+        const { stdout } = await execFileAsync(
+          "git",
+          [
+            "ls-remote",
+            "--heads",
+            `https://github.com/${entry.repo}.git`,
+            `refs/heads/${installation.ref}`,
+          ],
+          { timeout: 15_000 }
+        )
+        const latestCommit = stdout.trim().split(/\s+/)[0]
+        if (!/^[0-9a-f]{40,64}$/i.test(latestCommit ?? "")) return installation
+        return {
+          ...installation,
+          latestCommit,
+          updateAvailable: latestCommit !== installation.commit,
+        }
+      } catch {
+        return installation
+      }
+    })
+  )
+}
+
+function commandFailureMessage(error: unknown): string {
+  const failure = error as {
+    message?: unknown
+    stderr?: unknown
+    stdout?: unknown
+  }
+  const text = (value: unknown) => (typeof value === "string" ? value : "")
+  const details = [
+    text(failure.message).split("\n")[0] ?? "",
+    text(failure.stderr),
+    text(failure.stdout),
+  ]
+    .filter((value) => value.trim().length > 0)
+    .join("\n\n")
+    .replace(ANSI_ESCAPE_PATTERN, "")
+    .trim()
+  const message = details || String(error)
+  return message.length > MAX_INSTALL_ERROR_LENGTH
+    ? `${message.slice(0, MAX_INSTALL_ERROR_LENGTH)}\n\n[Output truncated by Paseo Cafe]`
+    : message
+}
+
+async function listInstalledPlugins() {
+  const { stdout } = await execFileAsync("paseo", ["plugin", "ls", "--json"], {
+    timeout: 30_000,
+  })
+  return z.array(installedPluginSchema).parse(JSON.parse(stdout))
+}
 
 // Keyed by resolved URL so switching the directorySettings override (e.g. to
 // a local dev server) doesn't serve a stale production-fetched cache, or vice
@@ -88,11 +174,28 @@ async function fetchDirectory(baseUrl: string | undefined, force = false) {
 export async function listDirectory(
   input: RpcInput<typeof directoryListRpc>
 ): Promise<RpcOutput<typeof directoryListRpc>> {
-  const { plugins, fetchedAt } = await fetchDirectory(
-    input.baseUrl,
-    input.force
+  const [directory, installed] = await Promise.all([
+    fetchDirectory(input.baseUrl, input.force),
+    listInstalledPlugins().then(
+      (installations) => ({ installations }),
+      (error) => ({
+        installations: [],
+        installationError: commandFailureMessage(error),
+      })
+    ),
+  ])
+  const installations = await addUpdateAvailability(
+    directory.plugins,
+    installed.installations
   )
-  return { plugins, fetchedAt }
+  const installationError =
+    "installationError" in installed ? installed.installationError : undefined
+  return {
+    plugins: directory.plugins,
+    fetchedAt: directory.fetchedAt,
+    installations,
+    ...(installationError ? { installationError } : {}),
+  }
 }
 
 function attachmentText(entry: DirectoryEntry): string {
@@ -199,31 +302,31 @@ export async function installDirectoryPlugin(
     const { stdout } = await execFileAsync("paseo", args, { timeout: 120_000 })
     return { ok: true, message: stdout.trim() || `Installed ${repo}.` }
   } catch (error) {
-    const failure = error as {
-      message?: unknown
-      stderr?: unknown
-      stdout?: unknown
+    return { ok: false, message: commandFailureMessage(error) }
+  }
+}
+
+export async function updateDirectoryPlugin(
+  input: RpcInput<typeof directoryUpdateRpc>
+): Promise<RpcOutput<typeof directoryUpdateRpc>> {
+  try {
+    const { stdout } = await execFileAsync(
+      "paseo",
+      ["plugin", "update", input.pluginId, "--json"],
+      { timeout: 120_000 }
+    )
+    const [result] = pluginUpdateResponseSchema.parse(JSON.parse(stdout))
+    if (!result) {
+      return { ok: false, message: `No update result for ${input.pluginId}.` }
     }
-    const text = (value: unknown) => (typeof value === "string" ? value : "")
-    // execFile puts "Command failed: <cmd>\n" in front of a copy of stderr, so
-    // only its first line is kept; otherwise every failure prints stderr twice
-    // and eats half of MAX_INSTALL_ERROR_LENGTH.
-    const details = [
-      text(failure.message).split("\n")[0] ?? "",
-      text(failure.stderr),
-      text(failure.stdout),
-    ]
-      .filter((value) => value.trim().length > 0)
-      .join("\n\n")
-      .replace(ANSI_ESCAPE_PATTERN, "")
-      .trim()
-    const message = details || String(error)
     return {
-      ok: false,
-      message:
-        message.length > MAX_INSTALL_ERROR_LENGTH
-          ? `${message.slice(0, MAX_INSTALL_ERROR_LENGTH)}\n\n[Output truncated by Paseo Cafe]`
-          : message,
+      ok: true,
+      updated: result.updated,
+      message: result.updated
+        ? `Updated ${input.pluginId} by ${result.commits} commit${result.commits === 1 ? "" : "s"}.`
+        : `${input.pluginId} is already up to date.`,
     }
+  } catch (error) {
+    return { ok: false, message: commandFailureMessage(error) }
   }
 }

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -8,11 +8,13 @@ import type {
   directoryListRpc,
   directorySearchRpc,
   directoryUpdateRpc,
+  directoryUpdateStatusRpc,
+  InstalledPlugin,
 } from "../shared/directory"
 import {
   DEFAULT_DIRECTORY_URL,
   directoryEntrySchema,
-  findInstallation,
+  findInstallations,
   getInstallCommand,
   getSiteUrl,
   HEALTH_LABELS,
@@ -31,7 +33,7 @@ const ANSI_ESCAPE_PATTERN = new RegExp(
   "g"
 )
 const directoryResponseSchema = z.object({
-  plugins: z.array(directoryEntrySchema),
+  plugins: z.array(directoryEntrySchema).max(500),
   generatedAt: z.iso.datetime({ offset: true, local: true }).optional(),
 })
 const pluginUpdateResponseSchema = z.array(
@@ -44,48 +46,201 @@ const pluginUpdateResponseSchema = z.array(
   })
 )
 const TRACKED_BRANCH_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/
+const UPDATE_STATUS_TTL_MS = 60_000
+const UPDATE_CHECK_CONCURRENCY = 4
+const GIT_ENV = { GIT_TERMINAL_PROMPT: "0" }
+const updateStatusCache = new Map<
+  string,
+  { expiresAt: number; value: Promise<InstalledPlugin> }
+>()
 
-async function addUpdateAvailability(
-  plugins: readonly DirectoryEntry[],
-  installations: readonly z.infer<typeof installedPluginSchema>[]
-) {
-  return Promise.all(
-    installations.map(async (installation) => {
-      if (
-        installation.source !== "git" ||
-        !installation.ref ||
-        !installation.commit ||
-        !TRACKED_BRANCH_PATTERN.test(installation.ref) ||
-        installation.ref.includes("..")
-      ) {
-        return installation
-      }
-      const entry = plugins.find(
-        (candidate) => findInstallation(candidate, [installation]) !== undefined
+export function buildPaseoInvocation(
+  args: readonly string[],
+  platform = process.platform
+): { executable: string; args: string[] } {
+  if (platform !== "win32") return { executable: "paseo", args: [...args] }
+  const tokens = ["paseo", ...args].map((value) => {
+    if (
+      value.includes(String.fromCharCode(0)) ||
+      value.includes('"') ||
+      /[\r\n&|<>()^%!]/.test(value)
+    ) {
+      throw new Error(
+        "Paseo CLI argument contains unsupported Windows shell characters"
       )
-      if (!entry || !isValidRepo(entry.repo)) return installation
-      try {
-        const { stdout } = await execFileAsync(
-          "git",
-          [
-            "ls-remote",
-            "--heads",
-            `https://github.com/${entry.repo}.git`,
-            `refs/heads/${installation.ref}`,
-          ],
-          { timeout: 15_000 }
-        )
-        const latestCommit = stdout.trim().split(/\s+/)[0]
-        if (!/^[0-9a-f]{40,64}$/i.test(latestCommit ?? "")) return installation
-        return {
-          ...installation,
-          latestCommit,
-          updateAvailable: latestCommit !== installation.commit,
-        }
-      } catch {
-        return installation
-      }
+    }
+    return `"${value}"`
+  })
+  return {
+    executable: process.env.ComSpec || "cmd.exe",
+    args: ["/d", "/s", "/c", tokens.join(" ")],
+  }
+}
+
+async function execPaseo(args: readonly string[], timeout: number) {
+  const invocation = buildPaseoInvocation(args)
+  return execFileAsync(invocation.executable, invocation.args, { timeout })
+}
+
+async function execGit(
+  cwd: string,
+  args: readonly string[],
+  timeout = 15_000
+): Promise<{ stdout: string; exitCode: number }> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd,
+      env: { ...process.env, ...GIT_ENV },
+      timeout,
     })
+    return { stdout, exitCode: 0 }
+  } catch (error) {
+    const failure = error as { code?: unknown; stdout?: unknown }
+    if (typeof failure.code !== "number") throw error
+    return {
+      stdout: typeof failure.stdout === "string" ? failure.stdout : "",
+      exitCode: failure.code,
+    }
+  }
+}
+
+type GitRunner = typeof execGit
+
+export async function inspectUpdateStatus(
+  installation: InstalledPlugin,
+  runGit: GitRunner = execGit
+): Promise<InstalledPlugin> {
+  if (
+    installation.source !== "git" ||
+    !installation.ref ||
+    !installation.commit ||
+    !TRACKED_BRANCH_PATTERN.test(installation.ref) ||
+    installation.ref.includes("..")
+  ) {
+    return { ...installation, updateState: "unknown" }
+  }
+  const branchRef = `refs/remotes/origin/${installation.ref}`
+  try {
+    const tracked = await runGit(installation.path, [
+      "show-ref",
+      "--verify",
+      "--quiet",
+      branchRef,
+    ])
+    if (tracked.exitCode === 1) {
+      if (/^[0-9a-f]{40,64}$/i.test(installation.ref)) {
+        return { ...installation, updateState: "pinned" }
+      }
+      const tag = await runGit(installation.path, [
+        "show-ref",
+        "--verify",
+        "--quiet",
+        `refs/tags/${installation.ref}`,
+      ])
+      if (tag.exitCode === 0) return { ...installation, updateState: "pinned" }
+      throw new Error("Tracked branch is unavailable")
+    }
+    if (tracked.exitCode !== 0)
+      throw new Error("Could not inspect tracked branch")
+    const fetched = await runGit(
+      installation.path,
+      ["fetch", "--prune", "--tags", "origin"],
+      120_000
+    )
+    if (fetched.exitCode !== 0) throw new Error("Could not fetch plugin source")
+    const latest = await runGit(installation.path, [
+      "rev-parse",
+      "--verify",
+      branchRef,
+    ])
+    const latestCommit = latest.stdout.trim()
+    if (latest.exitCode !== 0 || !/^[0-9a-f]{40,64}$/i.test(latestCommit)) {
+      throw new Error("Could not resolve tracked branch")
+    }
+    if (latestCommit === installation.commit) {
+      return { ...installation, latestCommit, updateState: "current" }
+    }
+    const ancestor = await runGit(installation.path, [
+      "merge-base",
+      "--is-ancestor",
+      installation.commit,
+      latestCommit,
+    ])
+    return {
+      ...installation,
+      latestCommit,
+      updateState: ancestor.exitCode === 0 ? "available" : "diverged",
+    }
+  } catch (error) {
+    return {
+      ...installation,
+      updateState: "unknown",
+      updateError: commandFailureMessage(error),
+    }
+  }
+}
+
+async function cachedUpdateStatus(
+  installation: InstalledPlugin
+): Promise<InstalledPlugin> {
+  const key = `${installation.path}\u0000${installation.ref ?? ""}\u0000${installation.commit ?? ""}`
+  const now = Date.now()
+  const cached = updateStatusCache.get(key)
+  if (cached && cached.expiresAt > now) return cached.value
+  if (updateStatusCache.size >= 500) {
+    for (const [cachedKey, entry] of updateStatusCache) {
+      if (entry.expiresAt <= now) updateStatusCache.delete(cachedKey)
+    }
+    if (updateStatusCache.size >= 500) {
+      const oldestKey = updateStatusCache.keys().next().value
+      if (oldestKey !== undefined) updateStatusCache.delete(oldestKey)
+    }
+  }
+  const value = inspectUpdateStatus(installation)
+  updateStatusCache.set(key, { expiresAt: now + UPDATE_STATUS_TTL_MS, value })
+  return value
+}
+
+export async function mapWithConcurrency<Input, Output>(
+  values: readonly Input[],
+  limit: number,
+  mapper: (value: Input) => Promise<Output>
+): Promise<Output[]> {
+  const output = new Array<Output>(values.length)
+  let nextIndex = 0
+  async function worker() {
+    while (nextIndex < values.length) {
+      const index = nextIndex++
+      output[index] = await mapper(values[index])
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, values.length) }, () => worker())
+  )
+  return output
+}
+
+async function addUpdateStatus(
+  plugins: readonly DirectoryEntry[],
+  installations: readonly InstalledPlugin[]
+): Promise<InstalledPlugin[]> {
+  const matched = new Map<string, InstalledPlugin>()
+  for (const entry of plugins) {
+    for (const installation of findInstallations(entry, installations)) {
+      if (installation.source === "git")
+        matched.set(installation.id, installation)
+    }
+  }
+  const checked = await mapWithConcurrency(
+    [...matched.values()],
+    UPDATE_CHECK_CONCURRENCY,
+    cachedUpdateStatus
+  )
+  const byId = new Map(
+    checked.map((installation) => [installation.id, installation])
+  )
+  return installations.map(
+    (installation) => byId.get(installation.id) ?? installation
   )
 }
 
@@ -112,10 +267,8 @@ function commandFailureMessage(error: unknown): string {
 }
 
 async function listInstalledPlugins() {
-  const { stdout } = await execFileAsync("paseo", ["plugin", "ls", "--json"], {
-    timeout: 30_000,
-  })
-  return z.array(installedPluginSchema).parse(JSON.parse(stdout))
+  const { stdout } = await execPaseo(["plugin", "ls", "--json"], 30_000)
+  return z.array(installedPluginSchema).max(500).parse(JSON.parse(stdout))
 }
 
 // Keyed by resolved URL so switching the directorySettings override (e.g. to
@@ -178,23 +331,25 @@ export async function listDirectory(
     fetchDirectory(input.baseUrl, input.force),
     listInstalledPlugins().then(
       (installations) => ({ installations }),
-      (error) => ({
-        installations: [],
-        installationError: commandFailureMessage(error),
-      })
+      (error) => ({ installationError: commandFailureMessage(error) })
     ),
   ])
-  const installations = await addUpdateAvailability(
-    directory.plugins,
-    installed.installations
-  )
-  const installationError =
-    "installationError" in installed ? installed.installationError : undefined
   return {
     plugins: directory.plugins,
     fetchedAt: directory.fetchedAt,
-    installations,
-    ...(installationError ? { installationError } : {}),
+    ...installed,
+  }
+}
+
+export async function listDirectoryUpdateStatus(
+  input: RpcInput<typeof directoryUpdateStatusRpc>
+): Promise<RpcOutput<typeof directoryUpdateStatusRpc>> {
+  const [directory, installations] = await Promise.all([
+    fetchDirectory(input.baseUrl),
+    listInstalledPlugins(),
+  ])
+  return {
+    installations: await addUpdateStatus(directory.plugins, installations),
   }
 }
 
@@ -296,10 +451,9 @@ export async function installDirectoryPlugin(
 
   const args = ["plugin", "add", repo, ...(path ? ["--path", path] : [])]
   try {
-    // execFile, not exec/shell — args are passed as an array straight to the
-    // process, so there's no shell to inject into even though repo/path
-    // ultimately came from a remote JSON response.
-    const { stdout } = await execFileAsync("paseo", args, { timeout: 120_000 })
+    // Arguments are passed as an array on Unix and strictly quoted through
+    // cmd.exe for npm's paseo.cmd shim on Windows.
+    const { stdout } = await execPaseo(args, 120_000)
     return { ok: true, message: stdout.trim() || `Installed ${repo}.` }
   } catch (error) {
     return { ok: false, message: commandFailureMessage(error) }
@@ -309,22 +463,62 @@ export async function installDirectoryPlugin(
 export async function updateDirectoryPlugin(
   input: RpcInput<typeof directoryUpdateRpc>
 ): Promise<RpcOutput<typeof directoryUpdateRpc>> {
+  const { entry, pluginId } = input
+  if (!isValidRepo(entry.repo)) {
+    return {
+      ok: false,
+      message: `"${entry.repo}" isn't a valid catalog repository.`,
+    }
+  }
+  if (entry.path !== undefined && !isValidInstallPath(entry.path)) {
+    return {
+      ok: false,
+      message: `"${entry.path}" isn't a valid plugin subpath.`,
+    }
+  }
+  if (entry.id === "paseo-cafe") {
+    return {
+      ok: false,
+      message: `Update Paseo Cafe outside the running plugin: paseo plugin update ${pluginId}`,
+    }
+  }
   try {
-    const { stdout } = await execFileAsync(
-      "paseo",
-      ["plugin", "update", input.pluginId, "--json"],
-      { timeout: 120_000 }
+    const installed = await listInstalledPlugins()
+    const target = findInstallations(entry, installed).find(
+      (installation) =>
+        installation.id === pluginId && installation.source === "git"
+    )
+    if (!target) {
+      return {
+        ok: false,
+        message: `Installed plugin ${pluginId} does not match ${entry.repo}${entry.path ? `/${entry.path}` : ""}.`,
+      }
+    }
+    const checked = await inspectUpdateStatus(target)
+    if (checked.updateState !== "available") {
+      return {
+        ok: false,
+        message:
+          checked.updateState === "current"
+            ? `${pluginId} is already up to date.`
+            : `Update status for ${pluginId} is ${checked.updateState}.`,
+      }
+    }
+    const { stdout } = await execPaseo(
+      ["plugin", "update", pluginId, "--json"],
+      120_000
     )
     const [result] = pluginUpdateResponseSchema.parse(JSON.parse(stdout))
     if (!result) {
-      return { ok: false, message: `No update result for ${input.pluginId}.` }
+      return { ok: false, message: `No update result for ${pluginId}.` }
     }
+    updateStatusCache.clear()
     return {
       ok: true,
       updated: result.updated,
       message: result.updated
-        ? `Updated ${input.pluginId} by ${result.commits} commit${result.commits === 1 ? "" : "s"}.`
-        : `${input.pluginId} is already up to date.`,
+        ? `Updated ${pluginId} by ${result.commits} commit${result.commits === 1 ? "" : "s"}.`
+        : `${pluginId} is already up to date.`,
     }
   } catch (error) {
     return { ok: false, message: commandFailureMessage(error) }

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -98,7 +98,10 @@ export const installedPluginSchema = z.object({
   ref: z.string().optional(),
   commit: z.string().optional(),
   latestCommit: z.string().optional(),
-  updateAvailable: z.boolean().default(false),
+  updateState: z
+    .enum(["unknown", "pinned", "current", "available", "diverged"])
+    .default("unknown"),
+  updateError: z.string().optional(),
 })
 
 export type InstalledPlugin = z.infer<typeof installedPluginSchema>
@@ -112,10 +115,18 @@ export const directoryListRpc = defineRpc({
     force: z.boolean().default(false),
   }),
   output: z.object({
-    plugins: z.array(directoryEntrySchema),
+    plugins: z.array(directoryEntrySchema).max(500),
     fetchedAt: z.iso.datetime({ offset: true, local: true }),
-    installations: z.array(installedPluginSchema),
+    installations: z.array(installedPluginSchema).max(500).optional(),
     installationError: z.string().optional(),
+  }),
+})
+
+export const directoryUpdateStatusRpc = defineRpc({
+  name: "directory.update-status",
+  input: z.object({ baseUrl: httpUrlSchema.optional() }),
+  output: z.object({
+    installations: z.array(installedPluginSchema).max(500),
   }),
 })
 
@@ -155,7 +166,14 @@ export const directoryInstallRpc = defineRpc({
 
 export const directoryUpdateRpc = defineRpc({
   name: "directory.update",
-  input: z.object({ pluginId: z.string().regex(/^[a-z][a-z0-9-]*$/) }),
+  input: z.object({
+    pluginId: z.string().regex(/^[a-z][a-z0-9-]*$/),
+    entry: z.object({
+      id: z.string(),
+      repo: z.string(),
+      path: z.string().optional(),
+    }),
+  }),
   output: z.object({
     ok: z.boolean(),
     message: z.string(),
@@ -196,7 +214,6 @@ export function getInstallCommand(
 export function getSiteUrl(entry: Pick<DirectoryEntry, "id">): string {
   return `${SITE_URL}/plugins/${encodeURIComponent(entry.id)}`
 }
-
 function githubRepoFromRemote(remote: string | undefined): string | undefined {
   if (!remote) return undefined
   const normalized = remote
@@ -204,10 +221,19 @@ function githubRepoFromRemote(remote: string | undefined): string | undefined {
     .replace(/\/$/, "")
     .replace(/\.git$/, "")
   const match =
-    /^(?:https?:\/\/|ssh:\/\/(?:git@)?|git@)github\.com[/:]([^/]+)\/([^/]+)$/i.exec(
+    /^(?:(?:https?|git):\/\/|ssh:\/\/(?:git@)?|git@)github\.com[/:]([^/]+)\/([^/]+)$/i.exec(
       normalized
     )
   return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined
+}
+function normalizePluginPath(path: string | undefined): string | undefined {
+  if (!path || path === ".") return undefined
+  const normalized = path
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/^\/+/, "")
+    .replace(/\/$/, "")
+  return normalized || undefined
 }
 
 function pluginPathFromCheckout(path: string): string | undefined {
@@ -215,26 +241,22 @@ function pluginPathFromCheckout(path: string): string | undefined {
   const marker = "/checkout"
   const index = normalized.lastIndexOf(marker)
   if (index < 0) return undefined
-  const pluginPath = normalized.slice(index + marker.length).replace(/^\/+/, "")
-  return pluginPath || undefined
+  return normalizePluginPath(normalized.slice(index + marker.length))
 }
 
-export function findInstallation(
+export function findInstallations(
   entry: Pick<DirectoryEntry, "id" | "repo" | "path">,
   installations: readonly InstalledPlugin[]
-): InstalledPlugin | undefined {
-  const byId = installations.find(
-    (installation) => installation.id === entry.id
-  )
-  if (byId) return byId
+): InstalledPlugin[] {
   const expectedRepo = entry.repo.toLowerCase()
-  const expectedPath = entry.path?.replace(/^\.\//, "").replace(/\/$/, "")
-  return installations.find(
-    (installation) =>
-      installation.source === "git" &&
+  const expectedPath = normalizePluginPath(entry.path)
+  return installations.filter((installation) => {
+    if (installation.source === "directory") return installation.id === entry.id
+    return (
       githubRepoFromRemote(installation.remote) === expectedRepo &&
       pluginPathFromCheckout(installation.path) === expectedPath
-  )
+    )
+  })
 }
 
 /**

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -88,6 +88,21 @@ export const directoryEntrySchema = z.object({
 
 export type DirectoryEntry = z.infer<typeof directoryEntrySchema>
 
+export const installedPluginSchema = z.object({
+  id: z.string(),
+  path: z.string(),
+  enabled: z.boolean(),
+  status: z.enum(["running", "failed", "disabled"]),
+  source: z.enum(["git", "directory"]).default("directory"),
+  remote: z.string().optional(),
+  ref: z.string().optional(),
+  commit: z.string().optional(),
+  latestCommit: z.string().optional(),
+  updateAvailable: z.boolean().default(false),
+})
+
+export type InstalledPlugin = z.infer<typeof installedPluginSchema>
+
 export const directoryListRpc = defineRpc({
   name: "directory.list",
   // baseUrl comes from the client's own directorySettings read — see
@@ -99,6 +114,8 @@ export const directoryListRpc = defineRpc({
   output: z.object({
     plugins: z.array(directoryEntrySchema),
     fetchedAt: z.iso.datetime({ offset: true, local: true }),
+    installations: z.array(installedPluginSchema),
+    installationError: z.string().optional(),
   }),
 })
 
@@ -136,6 +153,16 @@ export const directoryInstallRpc = defineRpc({
   }),
 })
 
+export const directoryUpdateRpc = defineRpc({
+  name: "directory.update",
+  input: z.object({ pluginId: z.string().regex(/^[a-z][a-z0-9-]*$/) }),
+  output: z.object({
+    ok: z.boolean(),
+    message: z.string(),
+    updated: z.boolean().optional(),
+  }),
+})
+
 // GitHub "owner/repo" — one slash, conservative charset. Checked on both sides:
 // the client disables Install for anything that fails this, and the server
 // re-checks it right before exec'ing the CLI, since that's the boundary that
@@ -168,6 +195,46 @@ export function getInstallCommand(
 
 export function getSiteUrl(entry: Pick<DirectoryEntry, "id">): string {
   return `${SITE_URL}/plugins/${encodeURIComponent(entry.id)}`
+}
+
+function githubRepoFromRemote(remote: string | undefined): string | undefined {
+  if (!remote) return undefined
+  const normalized = remote
+    .trim()
+    .replace(/\/$/, "")
+    .replace(/\.git$/, "")
+  const match =
+    /^(?:https?:\/\/|ssh:\/\/(?:git@)?|git@)github\.com[/:]([^/]+)\/([^/]+)$/i.exec(
+      normalized
+    )
+  return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined
+}
+
+function pluginPathFromCheckout(path: string): string | undefined {
+  const normalized = path.replace(/\\/g, "/").replace(/\/$/, "")
+  const marker = "/checkout"
+  const index = normalized.lastIndexOf(marker)
+  if (index < 0) return undefined
+  const pluginPath = normalized.slice(index + marker.length).replace(/^\/+/, "")
+  return pluginPath || undefined
+}
+
+export function findInstallation(
+  entry: Pick<DirectoryEntry, "id" | "repo" | "path">,
+  installations: readonly InstalledPlugin[]
+): InstalledPlugin | undefined {
+  const byId = installations.find(
+    (installation) => installation.id === entry.id
+  )
+  if (byId) return byId
+  const expectedRepo = entry.repo.toLowerCase()
+  const expectedPath = entry.path?.replace(/^\.\//, "").replace(/\/$/, "")
+  return installations.find(
+    (installation) =>
+      installation.source === "git" &&
+      githubRepoFromRemote(installation.remote) === expectedRepo &&
+      pluginPathFromCheckout(installation.path) === expectedPath
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary
- detect installed catalog plugins using verified repository and subpath provenance
- check tracked Git sources in a bounded, cached background request and distinguish current, available, pinned, diverged, and unavailable states
- support multiple runtime aliases without collapsing update targets
- show installed and update-available pills with All, Installed, Updates, and Not installed filters
- fail closed when inventory or update status is unavailable
- require confirmation with remote, ref, and commit details before updating trusted plugin code
- provide Windows-compatible Paseo CLI invocation and prevent in-process Paseo Cafe self-updates

## Verification
- `bun run check:plugin`
- `npm --prefix plugin run typecheck`
- `npm --prefix plugin test` (24 tests)
- exercised inventory failure handling and authoritative tracked-source status checks
- verified filters, status pills, current-version behavior, and desktop/compact layouts in the running Paseo client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added installation-status filters for directory plugins: All, Installed, Updates, and Not installed.
  - Added installation and update status badges to plugin listings.
  - Added per-installation update actions and confirmation prompts on plugin details.
  - Added update progress, error, and result messaging.
  - Directory listings now prioritize plugins with available updates.
  - Added clearer handling when plugin inventory is unavailable or installations cannot be inspected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->