### PR TITLE
Add review-deck

### DIFF
--- a/registry/review-deck.json
+++ b/registry/review-deck.json
@@ -1,0 +1,6 @@
+{
+  "repo": "mentalfl0w/review-deck",
+  "categories": ["productivity", "code-review", "git"],
+  "caveats": ["Requires Paseo 0.8.x (currently beta)."],
+  "submittedBy": "mentalfl0w"
+}


### PR DESCRIPTION
## Summary

- Add the public \`mentalfl0w/review-deck\` plugin to the Paseo Cafe registry.
- Classify it for productivity, code review, and Git workflows.
- Surface its Paseo 0.8.x beta requirement before install.

## Validation

- [x] \`bun run registry:validate\`
- [x] Confirmed the public repository manifest ID is \`review-deck\`
- [x] Confirmed the source repository's default branch contains its installation metadata and listing assets.

Source-repository listing updates are merged in https://github.com/mentalfl0w/review-deck/pull/1.