### PR TITLE
Add official Paseo Discord link

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -24,6 +24,18 @@ export function SiteFooter() {
           site. Read a plugin's source before installing it. See each plugin's
           page for details.
         </p>
+        <p>
+          Join the official Paseo community on{" "}
+          <a
+            href="https://discord.com/channels/1481169421832814616/1547511972830912593"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-3 hover:text-foreground"
+          >
+            Discord
+          </a>
+          .
+        </p>
         <p className="mt-3">
           Build with ❤︎⁠ as a joined collaboration by{" "}
           <a


### PR DESCRIPTION
## Summary
- add the official Paseo Discord channel to the site footer
- open the channel in a new tab

## Verification
- `bunx biome check src/components/site-footer.tsx`
- `bun run typecheck`