### PR TITLE
Add panrafal/paseo-plugins

### DIFF
--- a/registry/agent-heartbeats.json
+++ b/registry/agent-heartbeats.json
@@ -1,0 +1,9 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "agent-heartbeats",
+  "categories": ["productivity"],
+  "caveats": [
+    "Changing a heartbeat prompt or max-run count creates a replacement and resets run history"
+  ],
+  "submittedBy": "panrafal"
+}

--- a/registry/agents-dash-list.json
+++ b/registry/agents-dash-list.json
@@ -1,0 +1,9 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "agents-dash-list",
+  "categories": ["monitoring", "productivity"],
+  "caveats": [
+    "Unread marks stay on the daemon that stored them and do not sync across hosts"
+  ],
+  "submittedBy": "panrafal"
+}

--- a/registry/agents-history.json
+++ b/registry/agents-history.json
@@ -1,0 +1,9 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "agents-history",
+  "categories": ["monitoring", "productivity"],
+  "caveats": [
+    "Reads on-disk provider transcripts; writes only its own search index under plugin-data"
+  ],
+  "submittedBy": "panrafal"
+}

--- a/registry/chat-resume.json
+++ b/registry/chat-resume.json
@@ -1,0 +1,9 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "chat-resume",
+  "categories": ["productivity"],
+  "caveats": [
+    "Pills appear only when the latest agent error is a usage-limit / quota exhaustion"
+  ],
+  "submittedBy": "panrafal"
+}

--- a/registry/schedule-runs.json
+++ b/registry/schedule-runs.json
@@ -1,0 +1,9 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "schedule-runs",
+  "categories": ["monitoring", "productivity"],
+  "caveats": [
+    "Read-only feed of existing schedule runs; it does not create, pause, or delete schedules"
+  ],
+  "submittedBy": "panrafal"
+}

--- a/registry/session-usage.json
+++ b/registry/session-usage.json
@@ -1,0 +1,9 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "session-usage",
+  "categories": ["monitoring", "productivity"],
+  "caveats": [
+    "Reads local Claude and Codex transcripts; does not contact provider billing APIs"
+  ],
+  "submittedBy": "panrafal"
+}

--- a/registry/task-link.json
+++ b/registry/task-link.json
@@ -1,0 +1,9 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "task-link",
+  "categories": ["productivity"],
+  "caveats": [
+    "Shipped default matches CT-1234 Notion links; change the pattern and URL in settings first"
+  ],
+  "submittedBy": "panrafal"
+}

--- a/registry/vscode-open-remote.json
+++ b/registry/vscode-open-remote.json
@@ -1,0 +1,10 @@
+{
+  "repo": "panrafal/paseo-plugins",
+  "path": "vscode-open-remote",
+  "categories": ["productivity"],
+  "caveats": [
+    "Hidden on phones. Tablets need a VS Code tunnel whose name matches the Paseo host",
+    "Install on each remote daemon; a local install also adds pills there"
+  ],
+  "submittedBy": "panrafal"
+}


### PR DESCRIPTION
## Summary

- Add eight plugins from the public `panrafal/paseo-plugins` monorepo to the directory.
- Classify them as productivity and, where they surface agent/schedule/usage state, monitoring.
- Flag install caveats that are easy to miss (quota-only pills, Notion defaults, local-only unread marks, remote-editor tunnel).

## Plugins

| ID | Path |
| --- | --- |
| `agent-heartbeats` | `agent-heartbeats` |
| `agents-dash-list` | `agents-dash-list` |
| `agents-history` | `agents-history` |
| `chat-resume` | `chat-resume` |
| `schedule-runs` | `schedule-runs` |
| `session-usage` | `session-usage` |
| `task-link` | `task-link` |
| `vscode-open-remote` | `vscode-open-remote` |

## Validation

- [x] `bun run registry:validate`
- [x] Confirmed each `paseo-plugin.json` `id` matches the registry filename
- [x] Listings use `package.json` descriptions, `images/`, and Install/Limitations README sections on `panrafal/paseo-plugins` main


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added eight productivity and monitoring plugins to the available plugin registry.
  - New capabilities include heartbeat tracking, agent dashboards and history, chat resumption, scheduled-run monitoring, session usage insights, task linking, and remote VS Code access.
  - Registry entries now surface important limitations, including local-only data, read-only monitoring, quota-specific indicators, configuration requirements, and mobile device restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->