### PR TITLE
fix(plugin): sanitize Electron environment for CLI calls

### DIFF
--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -388,10 +388,16 @@ describe("update target validation", () => {
 })
 
 describe("Paseo CLI invocation", () => {
-  it("uses direct argv execution on Unix", () => {
-    expect(buildPaseoInvocation(["plugin", "ls", "--json"], "linux")).toEqual({
+  it("disables inherited Electron Node mode on Unix", () => {
+    expect(
+      buildPaseoInvocation(["plugin", "ls", "--json"], "linux", {
+        ELECTRON_RUN_AS_NODE: "1",
+        PATH: "/usr/bin",
+      })
+    ).toEqual({
       executable: "paseo",
       args: ["plugin", "ls", "--json"],
+      env: { PATH: "/usr/bin" },
     })
   })
 

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -57,9 +57,17 @@ const updateStatusCache = new Map<
 
 export function buildPaseoInvocation(
   args: readonly string[],
-  platform = process.platform
-): { executable: string; args: string[] } {
-  if (platform !== "win32") return { executable: "paseo", args: [...args] }
+  platform = process.platform,
+  env = process.env
+): { executable: string; args: string[]; env: NodeJS.ProcessEnv } {
+  const childEnv = { ...env }
+  // A plugin subprocess launched by the packaged Electron app inherits this.
+  // Passing it back to the AppImage makes Electron treat "plugin" as a Node
+  // entrypoint instead of dispatching the Paseo CLI.
+  delete childEnv.ELECTRON_RUN_AS_NODE
+  if (platform !== "win32") {
+    return { executable: "paseo", args: [...args], env: childEnv }
+  }
   const tokens = ["paseo", ...args].map((value) => {
     if (
       value.includes(String.fromCharCode(0)) ||
@@ -75,12 +83,16 @@ export function buildPaseoInvocation(
   return {
     executable: process.env.ComSpec || "cmd.exe",
     args: ["/d", "/s", "/c", tokens.join(" ")],
+    env: childEnv,
   }
 }
 
 async function execPaseo(args: readonly string[], timeout: number) {
   const invocation = buildPaseoInvocation(args)
-  return execFileAsync(invocation.executable, invocation.args, { timeout })
+  return execFileAsync(invocation.executable, invocation.args, {
+    timeout,
+    env: invocation.env,
+  })
 }
 
 async function execGit(


### PR DESCRIPTION
## Problem

Plugin subprocesses launched by the packaged Electron app inherit `ELECTRON_RUN_AS_NODE=1`. When Paseo Cafe invokes the packaged `paseo` executable, Electron then interprets the first CLI argument (`plugin`) as a Node entrypoint, producing errors such as `Cannot find module '/home/<user>/plugin'`.

## Fix

- remove `ELECTRON_RUN_AS_NODE` from child environments used for Paseo CLI commands
- preserve the rest of the inherited environment
- add regression coverage for the packaged Linux invocation

## Verification

- `npm test` (44 tests)
- `npm run typecheck`
- `bun run check:plugin`
- smoke-tested `paseo plugin ls --json` with an inherited `ELECTRON_RUN_AS_NODE=1`; exit code 0 and valid plugin array

Fixes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Paseo CLI launches from packaged Electron apps by preventing Electron-specific environment settings from being passed to child processes.
  - Preserved the existing system `PATH` when launching the CLI across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->