### PR TITLE
Add plugin sorting (latest, stars, updated) and refactor homepage

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,6 +24,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # Full history, not the default shallow clone: scripts/scan.ts reads
+          # each registry/<id>.json's first commit date via `git log` to know
+          # when a plugin was added to the directory (see firstAddedAt). A
+          # shallow checkout would only ever see "today", breaking the
+          # homepage's "Latest" sort.
+          fetch-depth: 0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ bun run dev                 # regenerate the listing, then serve http://localhos
 `.output/public`. Run `bun run registry:scan` explicitly to refresh it. Other useful scripts:
 `bun run typecheck`, `bun run lint`, `bun run test`.
 
+Unauthenticated GitHub API requests are capped at 60/hour and `registry:scan`/`registry:validate`
+will hit that fast. Put a token (no scopes needed) in a local `.env` as `GITHUB_TOKEN=...` — Bun
+loads it automatically — to raise that to 5,000/hour.
+
 ## Stack
 
 TanStack Start (file-based routes under `src/routes/`), shadcn/ui (`src/components/ui/`,

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -12,6 +12,7 @@
  * safest defaults, so the listing can surface it as "needs attention"
  * instead of the whole build breaking.
  */
+import { execFileSync } from "node:child_process"
 import {
   existsSync,
   mkdirSync,
@@ -79,12 +80,38 @@ function isRecent(iso: string): boolean {
   return pushed >= cutoff
 }
 
+/**
+ * When a registry entry first landed in the repo, i.e. when the plugin
+ * joined the directory — the earliest commit that added `relPath`. This is
+ * the only durable "date added" we have, since data/plugins.json itself is
+ * regenerated from scratch on every run (gitignored, never committed back to
+ * main) and the registry entry is the one hand-authored, version-controlled
+ * artifact per plugin. Requires full git history (the deploy workflow's
+ * checkout uses fetch-depth: 0); falls back to `fallback` for a shallow
+ * clone or a registry file that isn't committed yet.
+ */
+function firstAddedAt(relPath: string, fallback: string): string {
+  try {
+    const out = execFileSync(
+      "git",
+      ["log", "--diff-filter=A", "--follow", "--format=%aI", "--", relPath],
+      { cwd: ROOT, encoding: "utf8" }
+    ).trim()
+    if (!out) return fallback
+    const dates = out.split("\n")
+    return dates[dates.length - 1] ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
 async function scanOne(entryFile: string): Promise<PluginRecord> {
   const id = registryIdSchema.parse(entryFile.slice(0, -".json".length))
   const raw = JSON.parse(readFileSync(join(REGISTRY_DIR, entryFile), "utf8"))
   const entry = registryEntrySchema.parse(raw)
   const [owner, repo] = entry.repo.split("/")
   const scannedAt = new Date().toISOString()
+  const addedAt = firstAddedAt(join("registry", entryFile), scannedAt)
   const prefix = entry.path ? `${entry.path}/` : ""
   const fallbackUrl = `https://github.com/${entry.repo}${entry.path ? `/tree/HEAD/${entry.path}` : ""}`
 
@@ -109,6 +136,7 @@ async function scanOne(entryFile: string): Promise<PluginRecord> {
     images: [],
     videos: [],
     scannedAt,
+    addedAt,
   }
 
   try {
@@ -275,6 +303,7 @@ async function scanOne(entryFile: string): Promise<PluginRecord> {
       images,
       videos,
       scannedAt,
+      addedAt,
     }
 
     if (!manifestId) {

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -14,8 +14,8 @@ export function HomeHero() {
         <a href="https://paseo.sh" className="underline underline-offset-4">
           Paseo
         </a>{" "}
-        plugins. Every listing is generated straight from each plugin's own
-        repo — no forms to fill out, just point us at the code.
+        plugins. Every listing is generated straight from each plugin's own repo
+        — no forms to fill out, just point us at the code.
       </p>
     </div>
   )

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -1,0 +1,22 @@
+/** Static intro copy at the top of the homepage — no props, nothing dynamic. */
+export function HomeHero() {
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-4 px-6 pt-16 pb-2 text-center">
+      <div className="mx-auto flex items-center gap-1.5 text-foreground/50 text-xs">
+        <span className="size-1.5 rounded-full bg-primary" />
+        Community-run unofficial directory
+      </div>
+      <h1 className="font-semibold text-4xl tracking-tight">
+        A directory of paseo.sh plugins
+      </h1>
+      <p className="mx-auto max-w-xl text-foreground/70">
+        Browse community-built{" "}
+        <a href="https://paseo.sh" className="underline underline-offset-4">
+          Paseo
+        </a>{" "}
+        plugins. Every listing is generated straight from each plugin's own
+        repo — no forms to fill out, just point us at the code.
+      </p>
+    </div>
+  )
+}

--- a/src/components/plugin-grid.tsx
+++ b/src/components/plugin-grid.tsx
@@ -1,0 +1,21 @@
+import { PluginCard } from "@/components/plugin-card"
+import type { PluginRecord } from "@/lib/plugin-schema"
+
+/** The filtered/sorted results area on the homepage — a card grid, or an empty state when nothing matches. */
+export function PluginGrid({ plugins }: { plugins: PluginRecord[] }) {
+  if (plugins.length === 0) {
+    return (
+      <p className="py-12 text-center text-foreground/50 text-sm">
+        No plugins match your filters.
+      </p>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {plugins.map((plugin) => (
+        <PluginCard key={plugin.id} plugin={plugin} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/plugin-sidebar.tsx
+++ b/src/components/plugin-sidebar.tsx
@@ -43,6 +43,7 @@ export function PluginSidebar({
             value={query}
             onChange={(e) => onQueryChange(e.target.value)}
             placeholder="Search plugins…"
+            aria-label="Search plugins"
           />
         </InputGroup>
       </div>
@@ -58,6 +59,7 @@ export function PluginSidebar({
             onClick={() => onSortChange(option.value)}
             className="h-auto w-fit text-sm!"
             variant={sort === option.value ? "default" : "outline"}
+            aria-pressed={sort === option.value}
           >
             {option.label}
           </Button>
@@ -73,6 +75,7 @@ export function PluginSidebar({
           onClick={() => onCategoryChange(null)}
           className="h-auto w-fit text-sm!"
           variant={category === null ? "default" : "outline"}
+          aria-pressed={category === null}
         >
           All
           <span className="text-xs! opacity-70">{totalCount}</span>
@@ -84,6 +87,7 @@ export function PluginSidebar({
             onClick={() => onCategoryChange(c)}
             className="h-auto w-fit text-sm!"
             variant={category === c ? "default" : "outline"}
+            aria-pressed={category === c}
           >
             {c}
             <span className="text-xs! opacity-70">{categoryCounts.get(c)}</span>

--- a/src/components/plugin-sidebar.tsx
+++ b/src/components/plugin-sidebar.tsx
@@ -1,0 +1,104 @@
+import { IconSearch } from "@tabler/icons-react"
+import { Link } from "@tanstack/react-router"
+import { Button } from "@/components/ui/button"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+import { SORT_OPTIONS, type SortOption } from "@/lib/sort-plugins"
+
+interface PluginSidebarProps {
+  query: string
+  onQueryChange: (query: string) => void
+  sort: SortOption
+  onSortChange: (sort: SortOption) => void
+  category: string | null
+  onCategoryChange: (category: string | null) => void
+  categories: string[]
+  categoryCounts: Map<string, number>
+  totalCount: number
+}
+
+/** Homepage search box, sort, category filters, and the "Submit your plugin" CTA. */
+export function PluginSidebar({
+  query,
+  onQueryChange,
+  sort,
+  onSortChange,
+  category,
+  onCategoryChange,
+  categories,
+  categoryCounts,
+  totalCount,
+}: PluginSidebarProps) {
+  return (
+    <aside className="flex flex-col gap-3 bg-card p-3 lg:sticky lg:top-20 lg:w-64 lg:shrink-0 lg:self-start">
+      <div className="relative">
+        <InputGroup>
+          <InputGroupAddon align={"inline-start"}>
+            <IconSearch />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder="Search plugins…"
+          />
+        </InputGroup>
+      </div>
+
+      <span className="font-medium text-foreground/50 text-xs uppercase tracking-wide">
+        Sort by
+      </span>
+      <div className="flex flex-wrap gap-1">
+        {SORT_OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            size={"sm"}
+            onClick={() => onSortChange(option.value)}
+            className="h-auto w-fit text-sm!"
+            variant={sort === option.value ? "default" : "outline"}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+
+      <span className="font-medium text-foreground/50 text-xs uppercase tracking-wide">
+        Categories
+      </span>
+      <div className="flex flex-wrap gap-1">
+        <Button
+          size={"sm"}
+          onClick={() => onCategoryChange(null)}
+          className="h-auto w-fit text-sm!"
+          variant={category === null ? "default" : "outline"}
+        >
+          All
+          <span className="text-xs! opacity-70">{totalCount}</span>
+        </Button>
+        {categories.map((c) => (
+          <Button
+            key={c}
+            size={"sm"}
+            onClick={() => onCategoryChange(c)}
+            className="h-auto w-fit text-sm!"
+            variant={category === c ? "default" : "outline"}
+          >
+            {c}
+            <span className="text-xs! opacity-70">{categoryCounts.get(c)}</span>
+          </Button>
+        ))}
+      </div>
+
+      <Button
+        nativeButton={false}
+        variant="outline"
+        className="w-full"
+        render={<Link to="/submit" />}
+      >
+        Submit your plugin
+      </Button>
+    </aside>
+  )
+}

--- a/src/lib/json-ld.test.ts
+++ b/src/lib/json-ld.test.ts
@@ -30,6 +30,7 @@ const basePlugin: PluginRecord = {
   images: [],
   videos: [],
   scannedAt: "2026-09-01T00:00:00.000Z",
+  addedAt: "2026-08-01T00:00:00.000Z",
 }
 
 describe("pluginJsonLd", () => {

--- a/src/lib/plugin-schema.test.ts
+++ b/src/lib/plugin-schema.test.ts
@@ -37,6 +37,7 @@ describe("pluginRecordSchema", () => {
         "https://raw.githubusercontent.com/mcowger/paseo-plugins/main/subagent-activity/images/a.png",
       ],
       scannedAt: new Date().toISOString(),
+      addedAt: new Date().toISOString(),
     })
     expect(result.success).toBe(true)
   })
@@ -60,6 +61,7 @@ describe("pluginRecordSchema", () => {
       images: [],
       scanError: "repo/path not found on GitHub: someone/deleted-repo",
       scannedAt: new Date().toISOString(),
+      addedAt: new Date().toISOString(),
     })
     expect(result.success).toBe(true)
   })
@@ -75,6 +77,7 @@ describe("pluginRecordSchema", () => {
       health: validHealth,
       images: [],
       scannedAt: new Date().toISOString(),
+      addedAt: new Date().toISOString(),
     })
     expect(result.platforms).toEqual([])
     expect(result.caveats).toEqual([])
@@ -96,6 +99,7 @@ describe("pluginRecordSchema", () => {
       health: validHealth,
       images: [],
       scannedAt: new Date().toISOString(),
+      addedAt: new Date().toISOString(),
     })
     expect(result.success).toBe(true)
   })

--- a/src/lib/plugin-schema.ts
+++ b/src/lib/plugin-schema.ts
@@ -97,6 +97,12 @@ export const pluginRecordSchema = z.object({
   videos: z.array(videoEmbedSchema).default([]),
   scanError: z.string().optional(),
   scannedAt: z.string(),
+  // When this plugin's registry/<id>.json entry first landed in the repo —
+  // i.e. when it joined the directory — read from git history at scan time
+  // (see scripts/scan.ts's firstAddedAt), not hand-maintained. Falls back to
+  // scannedAt when history isn't available (shallow clone, brand-new file).
+  // Powers the homepage's "Latest" sort.
+  addedAt: z.string(),
 })
 
 export type PluginHealth = z.infer<typeof pluginHealthSchema>

--- a/src/lib/sort-plugins.test.ts
+++ b/src/lib/sort-plugins.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest"
+import type { PluginRecord } from "@/lib/plugin-schema"
+import { sortPlugins } from "@/lib/sort-plugins"
+
+const health = {
+  manifestValid: true,
+  hasReadme: true,
+  hasLicense: true,
+  hasTests: true,
+  hasTypecheckScript: true,
+  updatedRecently: true,
+}
+
+function plugin(overrides: Partial<PluginRecord> & { id: string }): PluginRecord {
+  return {
+    repo: `owner/${overrides.id}`,
+    url: `https://github.com/owner/${overrides.id}`,
+    name: overrides.id,
+    description: "",
+    categories: [],
+    platforms: [],
+    caveats: [],
+    health,
+    images: [],
+    videos: [],
+    scannedAt: "2026-01-01T00:00:00.000Z",
+    addedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("sortPlugins", () => {
+  const plugins = [
+    plugin({
+      id: "old-popular",
+      addedAt: "2026-01-01T00:00:00.000Z",
+      repoMeta: {
+        stars: 100,
+        openIssues: 0,
+        defaultBranch: "main",
+        pushedAt: "2026-01-05T00:00:00.000Z",
+        topics: [],
+        archived: false,
+        license: null,
+      },
+    }),
+    plugin({
+      id: "new-unstarred",
+      addedAt: "2026-03-01T00:00:00.000Z",
+      repoMeta: {
+        stars: 1,
+        openIssues: 0,
+        defaultBranch: "main",
+        pushedAt: "2026-01-02T00:00:00.000Z",
+        topics: [],
+        archived: false,
+        license: null,
+      },
+    }),
+    plugin({
+      id: "broken-scan",
+      addedAt: "2026-02-01T00:00:00.000Z",
+      scanError: "repo not found",
+    }),
+    plugin({
+      id: "recently-pushed",
+      addedAt: "2026-01-15T00:00:00.000Z",
+      repoMeta: {
+        stars: 5,
+        openIssues: 0,
+        defaultBranch: "main",
+        pushedAt: "2026-04-01T00:00:00.000Z",
+        topics: [],
+        archived: false,
+        license: null,
+      },
+    }),
+  ]
+
+  it("orders 'latest' by addedAt, newest first", () => {
+    expect(sortPlugins(plugins, "latest").map((p) => p.id)).toEqual([
+      "new-unstarred",
+      "broken-scan",
+      "recently-pushed",
+      "old-popular",
+    ])
+  })
+
+  it("orders 'stars' by repoMeta.stars, treating a missing repoMeta as zero", () => {
+    expect(sortPlugins(plugins, "stars").map((p) => p.id)).toEqual([
+      "old-popular",
+      "recently-pushed",
+      "new-unstarred",
+      "broken-scan",
+    ])
+  })
+
+  it("orders 'updated' by repoMeta.pushedAt, falling back to scannedAt when missing", () => {
+    expect(sortPlugins(plugins, "updated").map((p) => p.id)).toEqual([
+      "recently-pushed",
+      "old-popular",
+      "new-unstarred",
+      "broken-scan",
+    ])
+  })
+
+  it("does not mutate the input array", () => {
+    const copy = [...plugins]
+    sortPlugins(plugins, "stars")
+    expect(plugins).toEqual(copy)
+  })
+})

--- a/src/lib/sort-plugins.test.ts
+++ b/src/lib/sort-plugins.test.ts
@@ -11,7 +11,9 @@ const health = {
   updatedRecently: true,
 }
 
-function plugin(overrides: Partial<PluginRecord> & { id: string }): PluginRecord {
+function plugin(
+  overrides: Partial<PluginRecord> & { id: string }
+): PluginRecord {
   return {
     repo: `owner/${overrides.id}`,
     url: `https://github.com/owner/${overrides.id}`,

--- a/src/lib/sort-plugins.ts
+++ b/src/lib/sort-plugins.ts
@@ -1,0 +1,47 @@
+import type { PluginRecord } from "@/lib/plugin-schema"
+
+/**
+ * Homepage sort options. "latest" (newest addition to the directory first)
+ * is the default — see addedAt on PluginRecord for how that's derived.
+ * "stars" and "updated" both read straight off repoMeta, which the scanner
+ * (scripts/scan.ts) always populates from the GitHub repo API.
+ *
+ * SORT_VALUES is the tuple form (mirrors PLATFORMS in registry-schema.ts) so
+ * the homepage route can build a `z.enum(SORT_VALUES)` for its ?sort= search
+ * param without duplicating the list of valid values.
+ */
+export const SORT_VALUES = ["latest", "stars", "updated"] as const
+export type SortOption = (typeof SORT_VALUES)[number]
+
+export const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: "latest", label: "Latest" },
+  { value: "stars", label: "Most starred" },
+  { value: "updated", label: "Recently updated" },
+]
+
+function time(iso: string): number {
+  return new Date(iso).getTime()
+}
+
+/** Newest-first by default so a broken scan (no repoMeta) never crashes the sort. */
+export function sortPlugins(
+  plugins: PluginRecord[],
+  sort: SortOption
+): PluginRecord[] {
+  const sorted = [...plugins]
+  switch (sort) {
+    case "stars":
+      sorted.sort((a, b) => (b.repoMeta?.stars ?? 0) - (a.repoMeta?.stars ?? 0))
+      break
+    case "updated":
+      sorted.sort(
+        (a, b) =>
+          time(b.repoMeta?.pushedAt ?? b.scannedAt) -
+          time(a.repoMeta?.pushedAt ?? a.scannedAt)
+      )
+      break
+    default:
+      sorted.sort((a, b) => time(b.addedAt) - time(a.addedAt))
+  }
+  return sorted
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { IconSearch } from "@tabler/icons-react"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
+import { z } from "zod"
 import { PluginCard } from "@/components/plugin-card"
 import { Button } from "@/components/ui/button"
 import {
@@ -11,18 +12,60 @@ import {
 import { listPlugins } from "@/lib/plugins-data"
 import { seo } from "@/lib/seo"
 import { SITE_DESCRIPTION, SITE_NAME } from "@/lib/site"
+import { SORT_OPTIONS, sortPlugins, SORT_VALUES } from "@/lib/sort-plugins"
+
+/**
+ * Search, category, and sort all live in the URL (?q=&category=&sort=)
+ * rather than component state, so following a plugin link and hitting the
+ * browser's back button lands you back on the same filtered/sorted view
+ * instead of a reset one. The default sort ("latest") is treated as absent
+ * so the URL stays clean when nothing's been changed from the default.
+ */
+const homeSearchSchema = z.object({
+  q: z.string().optional().catch(undefined),
+  category: z.string().optional().catch(undefined),
+  sort: z.enum(SORT_VALUES).optional().catch(undefined),
+})
 
 export const Route = createFileRoute("/")({
   head: () =>
     seo({ title: SITE_NAME, description: SITE_DESCRIPTION, path: "/" }),
   component: App,
   loader: () => listPlugins(),
+  validateSearch: homeSearchSchema,
 })
 
 function App() {
   const plugins = Route.useLoaderData()
-  const [query, setQuery] = useState("")
-  const [category, setCategory] = useState<string | null>(null)
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  const query = search.q ?? ""
+  const category = search.category ?? null
+  const sort = search.sort ?? "latest"
+
+  // Filter/sort changes replace the current history entry instead of
+  // pushing a new one — otherwise every keystroke or filter click would add
+  // a back-button stop of its own. The URL (and thus the state) is still
+  // fully restored when navigating back from a plugin's own page.
+  const setQuery = (q: string) =>
+    navigate({
+      search: (prev) => ({ ...prev, q: q || undefined }),
+      replace: true,
+    })
+  const setCategory = (next: string | null) =>
+    navigate({
+      search: (prev) => ({ ...prev, category: next ?? undefined }),
+      replace: true,
+    })
+  const setSort = (next: (typeof SORT_OPTIONS)[number]["value"]) =>
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        sort: next === "latest" ? undefined : next,
+      }),
+      replace: true,
+    })
 
   const categoryCounts = useMemo(() => {
     const counts = new Map<string, number>()
@@ -38,7 +81,7 @@ function App() {
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
-    return plugins.filter((plugin) => {
+    const matches = plugins.filter((plugin) => {
       if (category && !plugin.categories.includes(category)) return false
       if (!q) return true
       return (
@@ -47,7 +90,8 @@ function App() {
         plugin.id.toLowerCase().includes(q)
       )
     })
-  }, [plugins, query, category])
+    return sortPlugins(matches, sort)
+  }, [plugins, query, category, sort])
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 pb-20">
@@ -100,6 +144,23 @@ function App() {
                 placeholder="Search plugins…"
               />
             </InputGroup>
+          </div>
+
+          <span className="font-medium text-foreground/50 text-xs uppercase tracking-wide">
+            Sort by
+          </span>
+          <div className="flex flex-wrap gap-1">
+            {SORT_OPTIONS.map((option) => (
+              <Button
+                key={option.value}
+                size={"sm"}
+                onClick={() => setSort(option.value)}
+                className="h-auto w-fit text-sm!"
+                variant={sort === option.value ? "default" : "outline"}
+              >
+                {option.label}
+              </Button>
+            ))}
           </div>
 
           <span className="font-medium text-foreground/50 text-xs uppercase tracking-wide">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ import { PluginSidebar } from "@/components/plugin-sidebar"
 import { listPlugins } from "@/lib/plugins-data"
 import { seo } from "@/lib/seo"
 import { SITE_DESCRIPTION, SITE_NAME } from "@/lib/site"
-import { sortPlugins, SORT_VALUES } from "@/lib/sort-plugins"
+import { SORT_VALUES, sortPlugins } from "@/lib/sort-plugins"
 
 /**
  * Search, category, and sort all live in the URL (?q=&category=&sort=)

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,18 +1,13 @@
-import { IconSearch } from "@tabler/icons-react"
-import { createFileRoute, Link } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { useMemo } from "react"
 import { z } from "zod"
-import { PluginCard } from "@/components/plugin-card"
-import { Button } from "@/components/ui/button"
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-} from "@/components/ui/input-group"
+import { HomeHero } from "@/components/home-hero"
+import { PluginGrid } from "@/components/plugin-grid"
+import { PluginSidebar } from "@/components/plugin-sidebar"
 import { listPlugins } from "@/lib/plugins-data"
 import { seo } from "@/lib/seo"
 import { SITE_DESCRIPTION, SITE_NAME } from "@/lib/site"
-import { SORT_OPTIONS, sortPlugins, SORT_VALUES } from "@/lib/sort-plugins"
+import { sortPlugins, SORT_VALUES } from "@/lib/sort-plugins"
 
 /**
  * Search, category, and sort all live in the URL (?q=&category=&sort=)
@@ -58,7 +53,7 @@ function App() {
       search: (prev) => ({ ...prev, category: next ?? undefined }),
       replace: true,
     })
-  const setSort = (next: (typeof SORT_OPTIONS)[number]["value"]) =>
+  const setSort = (next: (typeof SORT_VALUES)[number]) =>
     navigate({
       search: (prev) => ({
         ...prev,
@@ -95,112 +90,28 @@ function App() {
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 pb-20">
-      <div className="mx-auto flex max-w-2xl flex-col gap-4 px-6 pt-16 pb-2 text-center">
-        <div className="mx-auto flex items-center gap-1.5 text-foreground/50 text-xs">
-          <span className="size-1.5 rounded-full bg-primary" />
-          Community-run unofficial directory
-        </div>
-        <h1 className="font-semibold text-4xl tracking-tight">
-          A directory of paseo.sh plugins
-        </h1>
-        <p className="mx-auto max-w-xl text-foreground/70">
-          Browse community-built{" "}
-          <a href="https://paseo.sh" className="underline underline-offset-4">
-            Paseo
-          </a>{" "}
-          plugins. Every listing is generated straight from each plugin's own
-          repo — no forms to fill out, just point us at the code.
-        </p>
-      </div>
+      <HomeHero />
 
       <p className="text-foreground/60 text-sm">
         {query || category
           ? `${filtered.length} of ${plugins.length} plugin${plugins.length === 1 ? "" : "s"} found.`
           : `${plugins.length} plugin${plugins.length === 1 ? "" : "s"} generated from their source repos.`}
       </p>
-      <div className="mx-auto flex w-full flex-col gap-8 lg:flex-row lg:items-start">
+      <div className="mx-auto flex w-full flex-col-reverse gap-8 lg:flex-row lg:items-start">
         <div className="min-w-0 flex-1">
-          {filtered.length === 0 ? (
-            <p className="py-12 text-center text-foreground/50 text-sm">
-              No plugins match your filters.
-            </p>
-          ) : (
-            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-              {filtered.map((plugin) => (
-                <PluginCard key={plugin.id} plugin={plugin} />
-              ))}
-            </div>
-          )}
+          <PluginGrid plugins={filtered} />
         </div>
-        <aside className="flex flex-col gap-3 bg-card p-3 lg:sticky lg:top-20 lg:w-64 lg:shrink-0 lg:self-start">
-          <div className="relative">
-            <InputGroup>
-              <InputGroupAddon align={"inline-start"}>
-                <IconSearch />
-              </InputGroupAddon>
-              <InputGroupInput
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search plugins…"
-              />
-            </InputGroup>
-          </div>
-
-          <span className="font-medium text-foreground/50 text-xs uppercase tracking-wide">
-            Sort by
-          </span>
-          <div className="flex flex-wrap gap-1">
-            {SORT_OPTIONS.map((option) => (
-              <Button
-                key={option.value}
-                size={"sm"}
-                onClick={() => setSort(option.value)}
-                className="h-auto w-fit text-sm!"
-                variant={sort === option.value ? "default" : "outline"}
-              >
-                {option.label}
-              </Button>
-            ))}
-          </div>
-
-          <span className="font-medium text-foreground/50 text-xs uppercase tracking-wide">
-            Categories
-          </span>
-          <div className="flex flex-wrap gap-1">
-            <Button
-              size={"sm"}
-              onClick={() => setCategory(null)}
-              className="h-auto w-fit text-sm!"
-              variant={category === null ? "default" : "outline"}
-            >
-              All
-              <span className="text-xs! opacity-70">{plugins.length}</span>
-            </Button>
-            {categories.map((c) => (
-              <Button
-                key={c}
-                size={"sm"}
-                onClick={() => setCategory(c)}
-                className="h-auto w-fit text-sm!"
-                variant={category === c ? "default" : "outline"}
-              >
-                {c}
-                <span className="text-xs! opacity-70">
-                  {categoryCounts.get(c)}
-                </span>
-              </Button>
-            ))}
-          </div>
-
-          <Button
-            nativeButton={false}
-            variant="outline"
-            className="w-full"
-            render={<Link to="/submit" />}
-          >
-            Submit your plugin
-          </Button>
-        </aside>
+        <PluginSidebar
+          query={query}
+          onQueryChange={setQuery}
+          sort={sort}
+          onSortChange={setSort}
+          category={category}
+          onCategoryChange={setCategory}
+          categories={categories}
+          categoryCounts={categoryCounts}
+          totalCount={plugins.length}
+        />
       </div>
     </div>
   )

--- a/src/routes/plugins.$id.tsx
+++ b/src/routes/plugins.$id.tsx
@@ -21,7 +21,7 @@ import type { PluginHealth } from "@/lib/plugin-schema"
 import { listPlugins } from "@/lib/plugins-data"
 import { PLATFORM_LABELS } from "@/lib/registry-schema"
 import { seo } from "@/lib/seo"
-import { SITE_NAME } from "@/lib/site"
+import { SITE_NAME, SITE_REPO } from "@/lib/site"
 
 export const Route = createFileRoute("/plugins/$id")({
   component: PluginDetail,
@@ -55,6 +55,12 @@ const HEALTH_LABELS: Record<keyof PluginHealth, string> = {
 
 function PluginDetail() {
   const plugin = Route.useLoaderData()
+  // plugin.owner comes from the GitHub API and is authoritative when present;
+  // repo.split("/")[0] is the same fallback used elsewhere on this page for
+  // a scan that errored before repoMeta/owner got populated.
+  const ownerLogin = plugin.owner?.login ?? plugin.repo.split("/")[0]
+  const isOfficialListing =
+    ownerLogin.toLowerCase() === SITE_REPO.split("/")[0].toLowerCase()
 
   return (
     <div className="flex flex-col gap-8">
@@ -145,25 +151,25 @@ function PluginDetail() {
           <IconExternalLink className="size-3.5" />
         </a>
       </div>
-
-      <Alert>
-        <IconAlertTriangle />
-        <AlertTitle>
-          Community-submitted — not owned or vetted by {SITE_NAME}
-        </AlertTitle>
-        <AlertDescription>
-          This listing is generated automatically from the plugin's own public
-          repository. We don't audit, endorse, or take responsibility for
-          third-party plugin code. Paseo plugins are trusted, unsandboxed code
-          with filesystem, process, and network access on the machine they run
-          on — read the source at{" "}
-          <a href={plugin.url} target="_blank" rel="noreferrer">
-            {plugin.repo}
-          </a>{" "}
-          before installing.
-        </AlertDescription>
-      </Alert>
-
+      {!isOfficialListing && (
+        <Alert>
+          <IconAlertTriangle />
+          <AlertTitle>
+            Community-submitted — not owned or vetted by {SITE_NAME}
+          </AlertTitle>
+          <AlertDescription>
+            This listing is generated automatically from the plugin's own
+            public repository. We don't audit, endorse, or take
+            responsibility for third-party plugin code. Paseo plugins are
+            trusted, unsandboxed code with filesystem, process, and network
+            access on the machine they run on — read the source at{" "}
+            <a href={plugin.url} target="_blank" rel="noreferrer">
+              {plugin.repo}
+            </a>{" "}
+            before installing.
+          </AlertDescription>
+        </Alert>
+      )}
       {plugin.paseoVersionRequirement ||
       plugin.platforms.length > 0 ||
       plugin.caveats.length > 0 ||

--- a/src/routes/plugins.$id.tsx
+++ b/src/routes/plugins.$id.tsx
@@ -158,11 +158,11 @@ function PluginDetail() {
             Community-submitted — not owned or vetted by {SITE_NAME}
           </AlertTitle>
           <AlertDescription>
-            This listing is generated automatically from the plugin's own
-            public repository. We don't audit, endorse, or take
-            responsibility for third-party plugin code. Paseo plugins are
-            trusted, unsandboxed code with filesystem, process, and network
-            access on the machine they run on — read the source at{" "}
+            This listing is generated automatically from the plugin's own public
+            repository. We don't audit, endorse, or take responsibility for
+            third-party plugin code. Paseo plugins are trusted, unsandboxed code
+            with filesystem, process, and network access on the machine they run
+            on — read the source at{" "}
             <a href={plugin.url} target="_blank" rel="noreferrer">
               {plugin.repo}
             </a>{" "}


### PR DESCRIPTION
## Changes

### Plugin Sorting
- Added three sort options to the homepage:
  - **Latest**: Newest additions to the directory (powered by git history via `addedAt`)
  - **Most starred**: Highest GitHub star count
  - **Recently updated**: Last push to repository
- Created `sortPlugins` library with full test coverage
- Sort state persists in URL query params (`?sort=stars`) so browser back/forward preserves the view

### Homepage Refactor
Extracted homepage into focused, reusable components:
- `HomeHero`: Static intro copy
- `PluginGrid`: Filtered/sorted results or empty state
- `PluginSidebar`: Search, sort buttons, category filters, and CTA

This improves maintainability and makes it easier to test individual UI sections.

### Plugin Directory Metadata
- Added `addedAt` field to `PluginRecord` (schema, tests)
- New `firstAddedAt()` function in scan.ts reads git log to find when each plugin was added
- Falls back gracefully to `scannedAt` for shallow clones or uncommitted entries

### Supporting Changes
- Updated GitHub Actions workflow to use `fetch-depth: 0` so scan.ts can read full commit history
- Added README documentation about GitHub API rate limits and `.env` token setup
- Fixed plugin detail page: community warning now only shows for non-official plugins

## Why
Improves plugin discoverability on the homepage — users can now surface fresh submissions, popular plugins, or recently active projects based on their needs.

## Screenshots
<img width="1266" height="692" alt="image" src="https://github.com/user-attachments/assets/33b5a9ce-045a-466a-9bb5-b06d23df94e7" />
<img width="1323" height="810" alt="image" src="https://github.com/user-attachments/assets/3d3dcafb-7214-4c11-af71-a9ed92d689ae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added homepage introduction and responsive plugin grid with an empty-results state.
  - Added search, category filters with counts, and sorting by latest, popularity, or recent updates.
  - Search, filters, and sorting are preserved in shareable URL parameters.
  - Added a “Submit your plugin” call to action.
  - Plugin listings now show stable “date added” information for latest sorting.
  - Community-submission notices now appear only for non-official listings.

- **Documentation**
  - Documented GitHub API rate limits and local token configuration.

- **Bug Fixes**
  - Corrected latest sorting so shallow repository history no longer makes plugins appear newly added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->