### PR TITLE
feat(registry): migrate Omer plugins to monorepo

### DIFF
--- a/registry/agent-crew.json
+++ b/registry/agent-crew.json
@@ -1,6 +1,7 @@
 {
-  "repo": "omercnet/paseo-agent-crew",
+  "repo": "omercnet/paseo-plugins",
+  "path": "agent-crew",
   "categories": ["monitoring", "productivity", "orchestration"],
-  "caveats": ["Requires Paseo 0.7.2 or newer"],
+  "caveats": ["Requires Paseo 0.8.x"],
   "submittedBy": "omercnet"
 }

--- a/registry/agent-monitor.json
+++ b/registry/agent-monitor.json
@@ -1,10 +1,8 @@
 {
-  "repo": "omercnet/paseo-agent-monitor",
+  "repo": "omercnet/paseo-plugins",
+  "path": "agent-monitor",
   "categories": ["monitoring", "productivity"],
   "platforms": ["macos", "linux", "windows"],
-  "caveats": [
-    "Requires Paseo 0.7.0-beta.1 or newer; navigation requires a 0.7.0-beta.3 or newer client",
-    "Web and desktop only until Paseo issue #3930 is fixed"
-  ],
+  "caveats": ["Requires Paseo 0.8.x"],
   "submittedBy": "omercnet"
 }

--- a/registry/fresh-worktrees.json
+++ b/registry/fresh-worktrees.json
@@ -1,0 +1,11 @@
+{
+  "repo": "omercnet/paseo-plugins",
+  "path": "fresh-worktrees",
+  "categories": ["automation", "git", "productivity"],
+  "platforms": ["macos", "linux", "windows"],
+  "caveats": [
+    "Requires Paseo 0.8.0-beta.1 or newer",
+    "Fetch failures stop branch-off worktree creation rather than using stale refs"
+  ],
+  "submittedBy": "omercnet"
+}

--- a/registry/paseo-dracula.json
+++ b/registry/paseo-dracula.json
@@ -1,6 +1,7 @@
 {
-  "repo": "omercnet/paseo-dracula",
+  "repo": "omercnet/paseo-plugins",
+  "path": "paseo-dracula",
   "categories": ["theme"],
-  "caveats": ["Requires Paseo 0.7.2 or newer"],
+  "caveats": ["Requires Paseo 0.8.x"],
   "submittedBy": "omercnet"
 }

--- a/registry/pr-radar.json
+++ b/registry/pr-radar.json
@@ -1,9 +1,10 @@
 {
-  "repo": "omercnet/paseo-pr-radar",
+  "repo": "omercnet/paseo-plugins",
+  "path": "pr-radar",
   "categories": ["monitoring", "productivity", "github"],
   "caveats": [
     "Requires an authenticated gh CLI on the daemon host",
-    "Requires Paseo 0.7.0-beta.3 or newer"
+    "Requires Paseo 0.8.x"
   ],
   "submittedBy": "omercnet"
 }

--- a/registry/shared-browser.json
+++ b/registry/shared-browser.json
@@ -1,5 +1,6 @@
 {
-  "repo": "omercnet/paseo-shared-browser",
+  "repo": "omercnet/paseo-plugins",
+  "path": "paseo-shared-browser",
   "categories": ["browser", "productivity"],
   "caveats": [
     "Installs a dedicated Chromium download of roughly 180 MB on the daemon host",


### PR DESCRIPTION
## Summary
- point Agent Crew, Agent Monitor, PR Radar, Shared Browser, and Dracula at their new `omercnet/paseo-plugins` subpaths
- update stale Paseo version caveats to the 0.8 plugin line
- add the Fresh Worktrees plugin

## Verification
- `bun run registry:validate` (27 entries)
- authenticated `bun run registry:scan` (27 clean, 0 warnings)
- `bun run check:app`
- `bun run typecheck`
- `bun run test` (96 tests)
- `bun run build:generated`