### PR TITLE
chore(plugin): update SDK to 0.8.0

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@getpaseo/plugin": "0.8.0-beta.1",
+        "@getpaseo/plugin": "0.8.0",
         "@tanstack/react-query": "^5.90.11",
         "@types/node": "^22",
         "@types/react": "~19.2.0",
@@ -518,29 +518,29 @@
       }
     },
     "node_modules/@getpaseo/client": {
-      "version": "0.8.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@getpaseo/client/-/client-0.8.0-beta.1.tgz",
-      "integrity": "sha512-+JHqeg4eCWYa3TqMNN1FLaDWpoXM6PrPArOpzfV/Qm+2Mhw/bA07QS+zjMzDpVz7QZ+z6eN/96qAbQ1eFOD6Zg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@getpaseo/client/-/client-0.8.0.tgz",
+      "integrity": "sha512-sX0PPR47a9MoK4cUpZXo4vrZLSfP39/l9jlxYslQTGTiXE/9g6EDr6XlRQZVlTkgZZ47xGRVJZ/wxhE37nLWkw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@getpaseo/protocol": "0.8.0-beta.1",
-        "@getpaseo/relay": "0.8.0-beta.1",
+        "@getpaseo/protocol": "0.8.0",
+        "@getpaseo/relay": "0.8.0",
         "zod": "^4.4.3"
       }
     },
     "node_modules/@getpaseo/plugin": {
-      "version": "0.8.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@getpaseo/plugin/-/plugin-0.8.0-beta.1.tgz",
-      "integrity": "sha512-7/4cAfd3+GNB8rEYytFbp+Z8x/QfXlLIGMa8pcdn2YgrQUuO8Hjc3L9CGan3IoAYva/ttQn9biCOvvVWcDmMoQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@getpaseo/plugin/-/plugin-0.8.0.tgz",
+      "integrity": "sha512-VWdqMuYhv6oVrbNr+phDkSkMd4qfjb55UkFB0S4u4sHgo66UtJwvn8U9bwp1zU5wktW2LdXEa4OpcEGFDSkdVw==",
       "dev": true,
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "@getpaseo/client": "0.8.0-beta.1",
-        "@getpaseo/protocol": "0.8.0-beta.1",
+        "@getpaseo/client": "0.8.0",
+        "@getpaseo/protocol": "0.8.0",
         "react": "~19.1.0",
         "react-native": ">=0.81.5",
         "zod": "^4.4.3"
@@ -552,9 +552,9 @@
       }
     },
     "node_modules/@getpaseo/protocol": {
-      "version": "0.8.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@getpaseo/protocol/-/protocol-0.8.0-beta.1.tgz",
-      "integrity": "sha512-7GQfNTe8cGgWPQDvY4F6CwEe75HdtPB7d+XQ+SZYRWM4IGkQhgXPM6hGFaDqut9LAweKNYllttA2FaDAJmmo+g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@getpaseo/protocol/-/protocol-0.8.0.tgz",
+      "integrity": "sha512-SytigneLVG61useJ9yU400WFVWlqluwwUeWF/giRs0+ZOmgMSBZvYduqPAJdTRMAvJlrj62T/uVBH8gzMuHYLw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -563,9 +563,9 @@
       }
     },
     "node_modules/@getpaseo/relay": {
-      "version": "0.8.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@getpaseo/relay/-/relay-0.8.0-beta.1.tgz",
-      "integrity": "sha512-aZGmgbQEU/DgPCW/zOdKce//nWiuMU1N5ikMG1q0z2acRQNPwdAok9fQO3iuNIcTENF/32azpWqgsr/qeMp5gA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@getpaseo/relay/-/relay-0.8.0.tgz",
+      "integrity": "sha512-YBCMAI3WOx7HgEToryyB94Mnugb7o2opuxN6ZycVK+K2wk2T25aV0sG3enzlKVM1oyiFVoJxJrAZyGDWfWpxpQ==",
       "dev": true,
       "peer": true,
       "dependencies": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@getpaseo/plugin": "0.8.0-beta.1",
+    "@getpaseo/plugin": "0.8.0",
     "@tanstack/react-query": "^5.90.11",
     "@types/node": "^22",
     "@types/react": "~19.2.0",


### PR DESCRIPTION
## Summary
- update `@getpaseo/plugin` from `0.8.0-beta.1` to stable `0.8.0`
- refresh the plugin package lock with stable Paseo client, protocol, and relay packages

## Validation
- `npm run typecheck` (plugin)
- `npm test` (44 tests)
- `bun run check:plugin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin development dependency to the stable 0.8.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->