### PR TITLE
Add tomgrin10 paseo plugins

### DIFF
--- a/registry/paseo-defer.json
+++ b/registry/paseo-defer.json
@@ -1,0 +1,5 @@
+{
+  "repo": "tomgrin10/paseo-defer",
+  "categories": ["automation", "productivity"],
+  "submittedBy": "tomgrin10"
+}

--- a/registry/send-to-paseo.json
+++ b/registry/send-to-paseo.json
@@ -1,0 +1,10 @@
+{
+  "repo": "tomgrin10/send-to-paseo",
+  "path": "plugin",
+  "categories": ["github", "browser", "productivity"],
+  "caveats": [
+    "Full browser-side functionality needs the companion Chrome extension from the same repo (not distributed via this registry)",
+    "Needs `git` on the daemon host; `gh` is optional but improves PR title/branch detection and Graphite stack ranking"
+  ],
+  "submittedBy": "tomgrin10"
+}

--- a/registry/smart-session.json
+++ b/registry/smart-session.json
@@ -1,0 +1,5 @@
+{
+  "repo": "tomgrin10/paseo-smart-session",
+  "categories": ["monitoring", "productivity"],
+  "submittedBy": "tomgrin10"
+}


### PR DESCRIPTION
Adds three plugins:

- **send-to-paseo** — local HTTP bridge that starts a Paseo agent in the workspace belonging to a pull request, driven by a companion browser extension
- **paseo-defer** — defer messages to Paseo coding agents until a chosen time or usage-window reset
- **smart-session** (paseo-smart-session) — records Claude plan-usage history and lets a Paseo agent manage its own context

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three repositories to the registry:
    - Paseo Defer, categorized under automation and productivity.
    - Send to Paseo, with notes about requiring a companion Chrome extension and Git on the daemon host.
    - Paseo Smart Session, categorized under monitoring and productivity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->