### PR TITLE
fix(pages): publish the catalog entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "registry:scan": "bun run scripts/scan.ts",
     "registry:ensure": "bun run scripts/scan.ts --if-missing",
     "icons:build": "bun run scripts/build-icons.ts",
-    "build:generated": "vite build",
+    "build:generated": "vite build && bun run scripts/verify-pages-entrypoint.ts",
     "security:targets": "bun run scripts/plugin-security/targets.ts",
     "security:scan": "bun run scripts/plugin-security/scan.ts",
     "security:publish": "bun run scripts/plugin-security/publish.ts",

--- a/scripts/verify-pages-entrypoint.ts
+++ b/scripts/verify-pages-entrypoint.ts
@@ -1,0 +1,14 @@
+import { readFile } from "node:fs/promises"
+
+const entrypoint = await readFile(".output/public/index.html", "utf8").catch(
+  () => undefined
+)
+
+if (
+  !entrypoint?.includes("<title>paseo.cafe</title>") ||
+  !entrypoint?.includes("All plugins")
+) {
+  throw new Error(
+    "GitHub Pages build must emit a rendered .output/public/index.html catalog entrypoint"
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -37,20 +37,34 @@ function normalizeCategoryFilter(category: string): Category | "" {
     : ""
 }
 
-const searchSchema = z.object({
-  q: z.string().catch(HOME_SEARCH_DEFAULT.q),
+const routeSearchSchema = z.object({
+  q: z.string().optional().catch(undefined),
   category: z
     .string()
-    .catch(HOME_SEARCH_DEFAULT.category)
-    .transform(normalizeCategoryFilter),
-  sort: z.enum(sortValues).catch(HOME_SEARCH_DEFAULT.sort),
-  page: z.coerce.number().int().positive().catch(HOME_SEARCH_DEFAULT.page),
+    .optional()
+    .catch(undefined)
+    .transform((category) =>
+      category === undefined ? undefined : normalizeCategoryFilter(category)
+    ),
+  sort: z.enum(sortValues).optional().catch(undefined),
+  page: z.coerce.number().int().positive().optional().catch(undefined),
 })
 
-export type CatalogSearch = z.output<typeof searchSchema>
+export interface CatalogSearch {
+  q: string
+  category: Category | ""
+  sort: SortValue
+  page: number
+}
 
 export function parseCatalogSearch(search: unknown): CatalogSearch {
-  return searchSchema.parse(search)
+  const parsed = routeSearchSchema.parse(search)
+  return {
+    q: parsed.q ?? HOME_SEARCH_DEFAULT.q,
+    category: parsed.category ?? HOME_SEARCH_DEFAULT.category,
+    sort: parsed.sort ?? HOME_SEARCH_DEFAULT.sort,
+    page: parsed.page ?? HOME_SEARCH_DEFAULT.page,
+  }
 }
 
 export function clampCatalogPage(page: number, totalPages: number): number {
@@ -65,7 +79,7 @@ const collator = new Intl.Collator(undefined, {
 })
 
 export const Route = createFileRoute("/")({
-  validateSearch: parseCatalogSearch,
+  validateSearch: routeSearchSchema,
   head: () =>
     seo({ title: SITE_NAME, description: SITE_DESCRIPTION, path: "/" }),
   component: App,
@@ -74,7 +88,7 @@ export const Route = createFileRoute("/")({
 
 function App() {
   const plugins = Route.useLoaderData()
-  const search = Route.useSearch()
+  const search = parseCatalogSearch(Route.useSearch())
   const navigate = Route.useNavigate()
 
   const categoryCounts = useMemo(() => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,6 @@ const config = defineConfig({
     devtools(),
     tailwindcss(),
     tanstackStart(),
-    viteReact(),
     // GitHub Pages serves only files. Nitro prerenders the linked catalog
     // pages and fixed routes into .output/public and fails the build if any
     // route cannot be rendered.
@@ -25,6 +24,7 @@ const config = defineConfig({
         routes: ["/", "/submit", "/api/plugins"],
       },
     }),
+    viteReact(),
   ],
 })
 


### PR DESCRIPTION
## Problem

The GitHub Pages artifact emitted a zero-byte root `index` file instead of `index.html`, leaving the catalog entrypoint unavailable.

## Fix

- preserve implicit catalog search defaults without canonicalizing the root request away from its HTML response
- align Nitro before the React plugin
- fail every generated build unless `.output/public/index.html` contains the rendered catalog

## Verification

- `bun run check`
- `bun run test` (18 files, 140 tests)
- `bun run build:generated`
- static-server browser smoke: root renders `paseo.cafe` with 12 catalog links