### PR TITLE
Align plugin security scanner with Paseo 0.8

### DIFF
--- a/scripts/plugin-security/scan.test.ts
+++ b/scripts/plugin-security/scan.test.ts
@@ -1,6 +1,10 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import { boundedReport } from "./publish.ts"
-import { renderReport } from "./scan.ts"
+import { checkoutTargetRepository, renderReport } from "./scan.ts"
 import {
   REPORT_DETAILS_OPEN,
   type SecurityFinding,
@@ -40,6 +44,58 @@ function boundaryFinding(path: string): SecurityFinding {
     message: "cross-runtime import boundary violated",
   }
 }
+
+describe("target checkout", () => {
+  it("scans the immutable target commit instead of repository HEAD", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-checkout-"))
+    const source = join(root, "source")
+    const destination = join(root, "checkout")
+    execFileSync("git", ["init", "--quiet", source])
+    writeFileSync(join(source, "value.txt"), "selected")
+    execFileSync("git", ["add", "value.txt"], { cwd: source })
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Scanner Test",
+        "-c",
+        "user.email=scanner@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "selected",
+      ],
+      { cwd: source }
+    )
+    const selected = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: source,
+      encoding: "utf8",
+    }).trim()
+    writeFileSync(join(source, "value.txt"), "new head")
+    execFileSync("git", ["add", "value.txt"], { cwd: source })
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Scanner Test",
+        "-c",
+        "user.email=scanner@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "head",
+      ],
+      { cwd: source }
+    )
+
+    expect(checkoutTargetRepository(source, selected, destination)).toBe(
+      selected
+    )
+    expect(readFileSync(join(destination, "value.txt"), "utf8")).toBe(
+      "selected"
+    )
+  })
+})
 
 describe("security report", () => {
   it("renders each rule's guidance once across all plugins", () => {

--- a/scripts/plugin-security/scan.test.ts
+++ b/scripts/plugin-security/scan.test.ts
@@ -123,6 +123,31 @@ describe("security report", () => {
     expect(report).not.toContain("MiB")
   })
 
+  it("provides remediation for Paseo 0.8 compatibility findings", () => {
+    const findings: SecurityFinding[] = [
+      ["manifest", "missing"],
+      ["manifest", "requirements.unknown"],
+      ["entrypoint", "missing"],
+      ["boundary", "invalid-module-location"],
+      ["boundary", "runtime-module-import"],
+      ["boundary", "unsupported-sdk-import"],
+    ].map(([tool, ruleId]) => ({
+      tool,
+      ruleId,
+      severity: "high",
+      blocking: true,
+      path: ".",
+      message: "incompatible with Paseo 0.8",
+    }))
+
+    const report = renderReport(
+      securityResults({ example: pluginResult(findings) })
+    )
+
+    for (const finding of findings)
+      expect(report).toContain(`### \`${finding.tool}/${finding.ruleId}\``)
+  })
+
   it("fails report generation when a rule has no guidance", () => {
     const finding = { ...boundaryFinding("client/file.ts"), ruleId: "new-rule" }
     const results = securityResults({ example: pluginResult([finding]) })

--- a/scripts/plugin-security/scan.ts
+++ b/scripts/plugin-security/scan.ts
@@ -59,6 +59,49 @@ function main() {
     process.exitCode = 1
   }
 }
+function runGit(
+  args: string[],
+  cwd: string | undefined,
+  env: NodeJS.ProcessEnv
+): string {
+  const result = spawnSync("git", ["-c", "core.hooksPath=/dev/null", ...args], {
+    cwd,
+    env,
+    encoding: "utf8",
+    timeout: CLONE_TIMEOUT_MS,
+  })
+  if (result.status !== 0)
+    throw new Error(
+      result.error?.message ||
+        result.stderr ||
+        result.stdout ||
+        "git command failed"
+    )
+  return result.stdout.trim()
+}
+
+export function checkoutTargetRepository(
+  source: string,
+  commit: string,
+  destination: string,
+  env: NodeJS.ProcessEnv = scrubEnv()
+): string {
+  runGit(["init", "--quiet", destination], undefined, env)
+  runGit(
+    ["fetch", "--depth=1", "--filter=blob:none", "--no-tags", source, commit],
+    destination,
+    env
+  )
+  runGit(
+    ["checkout", "--quiet", "--detach", "--force", "FETCH_HEAD"],
+    destination,
+    env
+  )
+  const actualCommit = runGit(["rev-parse", "HEAD"], destination, env)
+  if (actualCommit !== commit)
+    throw new Error(`checked out ${actualCommit}, expected ${commit}`)
+  return actualCommit
+}
 
 function scanTarget(
   target: SecurityTarget,
@@ -67,38 +110,12 @@ function scanTarget(
   const temp = mkdtempSync(join(tmpdir(), "paseo-plugin-security-"))
   try {
     const repoDir = join(temp, "repo")
-    const env = scrubEnv()
-    const clone = spawnSync(
-      "git",
-      [
-        "-c",
-        "core.hooksPath=/dev/null",
-        "clone",
-        "--depth=1",
-        "--filter=blob:none",
-        "--no-tags",
-        "--single-branch",
-        `https://github.com/${target.repo}.git`,
-        repoDir,
-      ],
-      { env, encoding: "utf8", timeout: CLONE_TIMEOUT_MS }
+    const commit = checkoutTargetRepository(
+      `https://github.com/${target.repo}.git`,
+      target.commit,
+      repoDir,
+      scrubEnv()
     )
-    if (clone.status !== 0) {
-      throw new Error(
-        clone.error?.message ||
-          clone.stderr ||
-          clone.stdout ||
-          "git clone failed"
-      )
-    }
-    const rev = spawnSync("git", ["rev-parse", "HEAD"], {
-      cwd: repoDir,
-      env,
-      encoding: "utf8",
-    })
-    if (rev.status !== 0) {
-      throw new Error(rev.stderr || rev.stdout || "git rev-parse failed")
-    }
     const staticResult = scanStaticFiles({
       root: repoDir,
       pluginPath: target.path ?? ".",
@@ -109,7 +126,7 @@ function scanTarget(
       (finding) => finding.blocking
     ).length
     return {
-      commit: rev.stdout.trim(),
+      commit,
       scannedAt: generatedAt,
       status: blockingFindings ? "failed" : "passed",
       blockingFindings,

--- a/scripts/plugin-security/scan.ts
+++ b/scripts/plugin-security/scan.ts
@@ -180,18 +180,27 @@ const RULE_GUIDANCE: Record<string, RuleGuidance> = {
       "The scanner could not clone, resolve, or inspect the submitted plugin revision.",
     fix: "Verify the repository, ref, and plugin path are accessible and correct, then rerun the check.",
   },
+  "manifest/missing": {
+    issue: "The plugin root does not contain `paseo-plugin.json`.",
+    fix: "Add a manifest with a valid lowercase kebab-case `id` and `requirements.paseo` range.",
+  },
   "manifest/id": {
     issue:
-      "The plugin manifest is missing an id or its id differs from the registry entry.",
-    fix: "Set `paseo-plugin.json` → `id` to the exact registry id.",
+      "The plugin manifest is missing an id, uses an invalid id, or differs from the registry entry.",
+    fix: "Set `paseo-plugin.json` → `id` to the exact lowercase kebab-case registry id.",
   },
   "manifest/requirements": {
     issue: "The manifest's `requirements` value is not an object.",
     fix: 'Use an object such as `{ "paseo": ">=0.8.0" }`.',
   },
   "manifest/requirements.paseo": {
-    issue: "The declared Paseo requirement is not a valid npm semver range.",
-    fix: "Use a valid range such as `>=0.8.0` or `>=0.8.3 <0.9.0`.",
+    issue:
+      "The manifest is missing `requirements.paseo` or its value is not a valid npm semver range. Paseo 0.8 treats a missing range as a pre-0.8 plugin.",
+    fix: "Declare a valid range such as `>=0.8.0` or `>=0.8.3 <0.9.0`.",
+  },
+  "manifest/requirements.unknown": {
+    issue: "The manifest contains an unsupported requirement key.",
+    fix: "Remove the key. `paseo` is the only supported requirement.",
   },
   "manifest/build": {
     issue:
@@ -200,7 +209,7 @@ const RULE_GUIDANCE: Record<string, RuleGuidance> = {
   },
   "manifest/unknown": {
     issue:
-      "The manifest contains a key the current plugin format does not recognize.",
+      "The manifest contains a key the current plugin format does not recognize. Paseo rejects unknown top-level keys.",
     fix: "Remove the key. Supported top-level keys are `id`, `requirements`, and `build`.",
   },
   "manifest/json": {
@@ -208,13 +217,34 @@ const RULE_GUIDANCE: Record<string, RuleGuidance> = {
     fix: "Make the manifest valid JSON without comments or trailing commas.",
   },
   "entrypoint/legacy-index": {
-    issue: "Paseo 0.8 no longer loads the legacy `index.ts` plugin entrypoint.",
-    fix: "Move app contributions to `index.client.ts` or `.tsx`, daemon contributions to `index.server.ts`, or provide both.",
+    issue:
+      "Paseo 0.8 no longer loads the legacy `index.ts` or `index.tsx` plugin entrypoint.",
+    fix: "Move app contributions to `index.client.ts` or `.tsx`, daemon contributions to `index.server.ts` or `.tsx`, or provide both.",
+  },
+  "entrypoint/missing": {
+    issue:
+      "The plugin does not provide a Paseo 0.8 client or server entrypoint.",
+    fix: "Add `index.client.ts` or `.tsx`, `index.server.ts` or `.tsx`, or both at the plugin root.",
   },
   "boundary/cross-runtime-import": {
     issue:
       "The import crosses bundles that run in different environments. Client code cannot load server code, server code cannot load client code, and shared code cannot depend on either runtime.",
     fix: "Keep UI and React Native code under `client/`, Node code under `server/`, and runtime-neutral contracts and values under `shared/`. Client and server modules may both import shared modules.",
+  },
+  "boundary/invalid-module-location": {
+    issue:
+      "A runtime module imports plugin code from the root or outside `client/`, `server/`, and `shared/`.",
+    fix: "Move the imported module under the directory for its runtime and update the import path.",
+  },
+  "boundary/runtime-module-import": {
+    issue:
+      "The import uses a module owned by another runtime. Client and shared code cannot use Node or server SDK modules; server and shared code cannot use React or client SDK modules.",
+    fix: "Move runtime-specific work under `client/` or `server/` and keep `shared/` limited to runtime-neutral contracts and values.",
+  },
+  "boundary/unsupported-sdk-import": {
+    issue:
+      "The import uses a private, retired, or unknown Paseo plugin SDK entry.",
+    fix: "Use only the 0.8 SDK root, `/client`, `/client/ui`, `/client/react-native`, `/server`, `/server/provider`, or `/server/acp` entry appropriate to the module runtime.",
   },
 }
 

--- a/scripts/plugin-security/static-scan.test.ts
+++ b/scripts/plugin-security/static-scan.test.ts
@@ -24,6 +24,66 @@ describe("scanStaticFiles", () => {
     )
     expect(result.findings.some((f) => f.ruleId === "legacy-index")).toBe(true)
   })
+  it("enforces the strict manifest shape and runtime entry requirement", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    writeFileSync(
+      join(root, "paseo-plugin.json"),
+      JSON.stringify({
+        id: "Plugin",
+        requirements: { paseo: " ", node: ">=20" },
+        build: [["bun", " "]],
+        extra: true,
+      })
+    )
+
+    const result = scanStaticFiles({ root, registryId: "plugin" })
+    const rules = result.findings.map(
+      ({ tool, ruleId, blocking }) => `${tool}/${ruleId}:${blocking}`
+    )
+
+    expect(rules).toEqual([
+      "manifest/id:true",
+      "manifest/requirements.unknown:true",
+      "manifest/requirements.paseo:true",
+      "manifest/build:true",
+      "manifest/unknown:extra:true",
+      "entrypoint/missing:true",
+    ])
+  })
+
+  it("rejects requirements that only target pre-0.8 Paseo", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    writeFileSync(
+      join(root, "paseo-plugin.json"),
+      JSON.stringify({ id: "plugin", requirements: { paseo: "<0.8.0" } })
+    )
+    writeFileSync(
+      join(root, "index.server.ts"),
+      "export default () => () => {}"
+    )
+    expect(
+      scanStaticFiles({ root, registryId: "plugin" }).findings.some(
+        ({ ruleId }) => ruleId === "requirements.paseo"
+      )
+    ).toBe(true)
+  })
+
+  it("requires a manifest and recognizes legacy TSX entrypoints", () => {
+    const missing = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    expect(
+      scanStaticFiles({ root: missing }).findings.map(
+        ({ tool, ruleId }) => `${tool}/${ruleId}`
+      )
+    ).toEqual(["manifest/missing", "entrypoint/missing"])
+
+    const legacy = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    writeFileSync(join(legacy, "index.tsx"), "export default () => () => {}")
+    expect(
+      scanStaticFiles({ root: legacy }).findings.map(
+        ({ tool, ruleId }) => `${tool}/${ruleId}`
+      )
+    ).toEqual(["entrypoint/legacy-index", "manifest/missing"])
+  })
 
   it("ignores nested index files outside the plugin root", () => {
     const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
@@ -126,6 +186,44 @@ describe("scanStaticFiles", () => {
       "shared/from-server.ts",
     ])
   })
+  it("enforces SDK and host-module runtime ownership", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    mkdirSync(join(root, "client"))
+    mkdirSync(join(root, "server"))
+    mkdirSync(join(root, "shared"))
+    writeFileSync(
+      join(root, "paseo-plugin.json"),
+      JSON.stringify({ id: "plugin", requirements: { paseo: ">=0.8.0" } })
+    )
+    writeFileSync(
+      join(root, "index.client.ts"),
+      'import "node:fs"\nimport "@getpaseo/plugin/server"\nimport "./helper"'
+    )
+    writeFileSync(join(root, "helper.ts"), "export {}")
+    writeFileSync(join(root, "index.server.ts"), 'import "react"')
+    writeFileSync(
+      join(root, "shared", "contract.ts"),
+      'import type { PluginClientContext } from "@getpaseo/plugin/client"'
+    )
+    writeFileSync(
+      join(root, "client", "private.ts"),
+      'import "@getpaseo/plugin/client/host"'
+    )
+
+    const result = scanStaticFiles({ root, registryId: "plugin" })
+    const findings = result.findings.map(
+      ({ ruleId, path }) => `${ruleId}:${path}`
+    )
+
+    expect(findings).toEqual([
+      "unsupported-sdk-import:client/private.ts",
+      "runtime-module-import:index.client.ts",
+      "runtime-module-import:index.client.ts",
+      "invalid-module-location:index.client.ts",
+      "runtime-module-import:index.server.ts",
+      "runtime-module-import:shared/contract.ts",
+    ])
+  })
 
   it("flags symlinks", () => {
     const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
@@ -148,8 +246,13 @@ describe("scanStaticFiles", () => {
   it("excludes Git metadata from coverage", () => {
     const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
     mkdirSync(join(root, ".git", "objects"), { recursive: true })
-    const manifest = JSON.stringify({ id: "plugin" })
+    const manifest = JSON.stringify({
+      id: "plugin",
+      requirements: { paseo: ">=0.8.0" },
+    })
+    const entrypoint = "export default () => () => {}"
     writeFileSync(join(root, "paseo-plugin.json"), manifest)
+    writeFileSync(join(root, "index.server.ts"), entrypoint)
     writeFileSync(
       join(root, ".git", "objects", "pack"),
       Buffer.alloc(2_000_001)
@@ -157,8 +260,10 @@ describe("scanStaticFiles", () => {
 
     const result = scanStaticFiles({ root, registryId: "plugin" })
 
-    expect(result.files).toBe(1)
-    expect(result.bytes).toBe(Buffer.byteLength(manifest))
+    expect(result.files).toBe(2)
+    expect(result.bytes).toBe(
+      Buffer.byteLength(manifest) + Buffer.byteLength(entrypoint)
+    )
     expect(result.findings).toEqual([])
   })
 

--- a/scripts/plugin-security/static-scan.test.ts
+++ b/scripts/plugin-security/static-scan.test.ts
@@ -82,7 +82,21 @@ describe("scanStaticFiles", () => {
       scanStaticFiles({ root: legacy }).findings.map(
         ({ tool, ruleId }) => `${tool}/${ruleId}`
       )
-    ).toEqual(["entrypoint/legacy-index", "manifest/missing"])
+    ).toEqual(["manifest/missing", "entrypoint/legacy-index"])
+
+    writeFileSync(
+      join(legacy, "paseo-plugin.json"),
+      JSON.stringify({ id: "plugin", requirements: { paseo: ">=0.8.0" } })
+    )
+    writeFileSync(
+      join(legacy, "index.server.ts"),
+      "export default () => () => {}"
+    )
+    expect(
+      scanStaticFiles({ root: legacy, registryId: "plugin" }).findings.some(
+        ({ ruleId }) => ruleId === "legacy-index"
+      )
+    ).toBe(false)
   })
 
   it("ignores nested index files outside the plugin root", () => {
@@ -215,14 +229,84 @@ describe("scanStaticFiles", () => {
       ({ ruleId, path }) => `${ruleId}:${path}`
     )
 
-    expect(findings).toEqual([
-      "unsupported-sdk-import:client/private.ts",
-      "runtime-module-import:index.client.ts",
-      "runtime-module-import:index.client.ts",
-      "invalid-module-location:index.client.ts",
-      "runtime-module-import:index.server.ts",
-      "runtime-module-import:shared/contract.ts",
-    ])
+    expect(findings.sort()).toEqual(
+      [
+        "unsupported-sdk-import:client/private.ts",
+        "runtime-module-import:index.client.ts",
+        "runtime-module-import:index.client.ts",
+        "invalid-module-location:index.client.ts",
+        "runtime-module-import:index.server.ts",
+        "runtime-module-import:shared/contract.ts",
+      ].sort()
+    )
+  })
+  it("checks absolute and triple-slash imports without rejecting valid barrels", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    mkdirSync(join(root, "client", "node_modules", "dependency"), {
+      recursive: true,
+    })
+    mkdirSync(join(root, "node_modules", "root-dependency"), {
+      recursive: true,
+    })
+    mkdirSync(join(root, "server"))
+    mkdirSync(join(root, "shared"))
+    writeFileSync(
+      join(root, "paseo-plugin.json"),
+      JSON.stringify({ id: "plugin", requirements: { paseo: ">=0.8.0" } })
+    )
+    writeFileSync(
+      join(root, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: { "#server/*": ["server/*"] },
+        },
+      })
+    )
+    writeFileSync(
+      join(root, "index.client.ts"),
+      'import "./client"\nimport "/tmp/outside.ts"\nimport "#server/handler"\nimport "constructor"\nimport "root-dependency"'
+    )
+    writeFileSync(
+      join(root, "client", "index.ts"),
+      'import "./node_modules/dependency"\nexport default 1'
+    )
+    writeFileSync(
+      join(root, "client", "node_modules", "dependency", "index.js"),
+      'require("node:fs")'
+    )
+    writeFileSync(
+      join(root, "node_modules", "root-dependency", "package.json"),
+      JSON.stringify({ name: "root-dependency", main: "index.js" })
+    )
+    writeFileSync(
+      join(root, "node_modules", "root-dependency", "index.js"),
+      'require("node:child_process")'
+    )
+    writeFileSync(
+      join(root, "shared", "contract.ts"),
+      '/// <reference path="../server/handler.ts" />'
+    )
+    writeFileSync(
+      join(root, "server", "handler.ts"),
+      '/// <reference types="@tanstack/react-query" />'
+    )
+
+    const findings = scanStaticFiles({
+      root,
+      registryId: "plugin",
+    }).findings.map(({ ruleId, path }) => `${ruleId}:${path}`)
+
+    expect(findings.sort()).toEqual(
+      [
+        "invalid-module-location:index.client.ts",
+        "cross-runtime-import:index.client.ts",
+        "runtime-module-import:client/node_modules/dependency/index.js",
+        "runtime-module-import:node_modules/root-dependency/index.js",
+        "runtime-module-import:server/handler.ts",
+        "cross-runtime-import:shared/contract.ts",
+      ].sort()
+    )
   })
 
   it("flags symlinks", () => {
@@ -286,5 +370,33 @@ describe("scanStaticFiles", () => {
 
     expect(result.findings.some((f) => f.ruleId === "size-limit")).toBe(true)
     expect(result.findings.some((f) => f.ruleId === "incomplete")).toBe(true)
+  })
+
+  it("stops reading before exceeding the aggregate byte limit", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    writeFileSync(join(root, "first.bin"), Buffer.alloc(1_100_000))
+    writeFileSync(join(root, "second.bin"), Buffer.alloc(1_100_000))
+
+    const result = scanStaticFiles({ root })
+
+    expect(result.files).toBe(1)
+    expect(result.bytes).toBe(1_100_000)
+    expect(
+      result.findings.some((finding) => finding.ruleId === "incomplete")
+    ).toBe(true)
+  })
+
+  it("stops reading after the global file-count limit", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-security-"))
+    for (let index = 0; index < 250; index += 1)
+      writeFileSync(join(root, `${index.toString().padStart(3, "0")}.txt`), "x")
+
+    const result = scanStaticFiles({ root })
+
+    expect(result.files).toBe(200)
+    expect(result.bytes).toBe(200)
+    expect(
+      result.findings.some((finding) => finding.ruleId === "incomplete")
+    ).toBe(true)
   })
 })

--- a/scripts/plugin-security/static-scan.ts
+++ b/scripts/plugin-security/static-scan.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { lstatSync, readdirSync, readFileSync } from "node:fs"
+import { isBuiltin } from "node:module"
 import { dirname, join, normalize, relative, resolve } from "node:path"
 import * as semver from "semver"
 import * as ts from "typescript"
@@ -19,13 +20,74 @@ export type StaticScanOutput = {
 const MAX_FILES = 200
 const MAX_BYTES = 2_000_000
 const MAX_DEPTH = 6
+type ScanState = {
+  files: number
+  bytes: number
+  incomplete: boolean
+  manifest: boolean
+  clientEntry: boolean
+  serverEntry: boolean
+  legacyEntry: boolean
+}
+
+const PLUGIN_ID = /^[a-z][a-z0-9-]*$/
+const CODE_MODULE = /\.[cm]?[jt]sx?$/
+const RUNTIME_ENTRY = /^index\.(client|server)\.(?:ts|tsx)$/
+const LEGACY_ENTRY = /^index\.(?:ts|tsx)$/
+const CLIENT_ONLY_SDK: Record<string, true> = {
+  "@getpaseo/plugin/client": true,
+  "@getpaseo/plugin/client/ui": true,
+  "@getpaseo/plugin/client/react-native": true,
+}
+const SERVER_ONLY_SDK: Record<string, true> = {
+  "@getpaseo/plugin/server": true,
+  "@getpaseo/plugin/server/provider": true,
+  "@getpaseo/plugin/server/acp": true,
+}
+const SUPPORTED_SDK: Record<string, true> = {
+  "@getpaseo/plugin": true,
+  ...CLIENT_ONLY_SDK,
+  ...SERVER_ONLY_SDK,
+}
+const CLIENT_ONLY_MODULE =
+  /^(?:(?:@types\/)?react(?:-dom|-native)?|use-sync-external-store|@tanstack\/react-query)(?:\/|$)/
 
 export function scanStaticFiles(input: StaticScanInput): StaticScanOutput {
   const root = resolve(input.root, input.pluginPath ?? ".")
-  const state = { files: 0, bytes: 0, incomplete: false }
+  const state: ScanState = {
+    files: 0,
+    bytes: 0,
+    incomplete: false,
+    manifest: false,
+    clientEntry: false,
+    serverEntry: false,
+    legacyEntry: false,
+  }
   const findings: SecurityFinding[] = []
   const buildCommands: string[][] = []
   walk(root, root, 0, state, findings, buildCommands, input.registryId)
+  if (!state.manifest)
+    findings.push(
+      finding(
+        "manifest",
+        "missing",
+        "high",
+        true,
+        "paseo-plugin.json",
+        "plugin manifest is missing"
+      )
+    )
+  if (!state.clientEntry && !state.serverEntry && !state.legacyEntry)
+    findings.push(
+      finding(
+        "entrypoint",
+        "missing",
+        "high",
+        true,
+        ".",
+        "plugin has no Paseo 0.8 runtime entry"
+      )
+    )
   if (state.incomplete)
     findings.push(
       finding(
@@ -44,7 +106,7 @@ function walk(
   base: string,
   dir: string,
   depth: number,
-  state: { files: number; bytes: number; incomplete: boolean },
+  state: ScanState,
   findings: SecurityFinding[],
   buildCommands: string[][],
   registryId?: string
@@ -89,10 +151,17 @@ function walk(
     const content = readFileSync(full, "utf8")
     state.bytes += meta.size
     if (state.bytes > MAX_BYTES) state.incomplete = true
-    if (entry.name === "paseo-plugin.json")
+    if (rel === "paseo-plugin.json") {
+      state.manifest = true
       validateManifest(content, rel, registryId, findings, buildCommands)
-    if (/^(?:index\.(?:client|server)\.(?:ts|tsx)|index\.ts)$/.test(rel))
+    }
+    const entryMatch = RUNTIME_ENTRY.exec(rel)
+    if (entryMatch?.[1] === "client") state.clientEntry = true
+    if (entryMatch?.[1] === "server") state.serverEntry = true
+    if (LEGACY_ENTRY.test(rel)) {
+      state.legacyEntry = true
       validateEntrypoint(entry.name, rel, findings)
+    }
     scanBoundaries(content, rel, findings)
   }
 }
@@ -105,10 +174,14 @@ function validateManifest(
   buildCommands: string[][]
 ) {
   try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const value = JSON.parse(raw) as unknown
+    if (!value || typeof value !== "object" || Array.isArray(value))
+      throw new Error("manifest must be an object")
+    const parsed = value as Record<string, unknown>
     if (
       typeof parsed.id !== "string" ||
-      (registryId && parsed.id !== registryId)
+      !PLUGIN_ID.test(parsed.id) ||
+      (registryId !== undefined && parsed.id !== registryId)
     )
       findings.push(
         finding(
@@ -117,40 +190,62 @@ function validateManifest(
           "high",
           true,
           path,
-          "manifest id must match registry id"
+          "manifest id must be lowercase kebab-case and match registry id"
         )
       )
     const req = parsed.requirements
-    if (req !== undefined) {
-      if (!req || typeof req !== "object" || Array.isArray(req))
-        findings.push(
-          finding(
-            "manifest",
-            "requirements",
-            "high",
-            true,
-            path,
-            "requirements must be an object"
-          )
+    if (req === undefined) {
+      findings.push(
+        finding(
+          "manifest",
+          "requirements.paseo",
+          "high",
+          true,
+          path,
+          "requirements.paseo is required for Paseo 0.8 plugins"
         )
-      else {
-        const paseo = (req as { paseo?: unknown }).paseo
-        if (
-          paseo !== undefined &&
-          (typeof paseo !== "string" ||
-            !semver.validRange(paseo, { loose: false }))
+      )
+    } else if (!req || typeof req !== "object" || Array.isArray(req)) {
+      findings.push(
+        finding(
+          "manifest",
+          "requirements",
+          "high",
+          true,
+          path,
+          "requirements must be an object"
         )
+      )
+    } else {
+      const requirements = req as Record<string, unknown>
+      for (const key of Object.keys(requirements))
+        if (key !== "paseo")
           findings.push(
             finding(
               "manifest",
-              "requirements.paseo",
+              "requirements.unknown",
               "high",
               true,
               path,
-              "invalid requirements.paseo semver range"
+              `unknown manifest requirement ${key}`
             )
           )
-      }
+      const paseo = requirements.paseo
+      const range =
+        typeof paseo === "string" && paseo.trim().length > 0
+          ? semver.validRange(paseo, { loose: false })
+          : null
+      if (!range || !semver.intersects(range, ">=0.8.0"))
+        findings.push(
+          finding(
+            "manifest",
+            "requirements.paseo",
+            "high",
+            true,
+            path,
+            "requirements.paseo must be a valid range targeting Paseo 0.8 or newer"
+          )
+        )
     }
     if (parsed.build !== undefined) {
       if (
@@ -160,7 +255,7 @@ function validateManifest(
           (cmd) =>
             Array.isArray(cmd) &&
             cmd.length > 0 &&
-            cmd.every((arg) => typeof arg === "string" && arg.length > 0)
+            cmd.every((arg) => typeof arg === "string" && arg.trim().length > 0)
         )
       )
         findings.push(
@@ -181,8 +276,8 @@ function validateManifest(
           finding(
             "manifest",
             `unknown:${key}`,
-            "medium",
-            false,
+            "high",
+            true,
             path,
             `unknown manifest key ${key}`
           )
@@ -198,7 +293,7 @@ function validateEntrypoint(
   path: string,
   findings: SecurityFinding[]
 ) {
-  if (name === "index.ts")
+  if (name === "index.ts" || name === "index.tsx")
     findings.push(
       finding(
         "entrypoint",
@@ -211,10 +306,13 @@ function validateEntrypoint(
     )
 }
 type PluginRuntime = "client" | "server" | "shared"
+type PluginModuleLocation = PluginRuntime | "invalid"
 
-function runtimeForPath(path: string): PluginRuntime | null {
+function runtimeForPath(path: string): PluginModuleLocation | null {
   const parts = path.split(/[\\/]/)
+  if (parts[0] === "..") return "invalid"
   const directory = parts.length > 1 ? parts[0] : undefined
+  if (directory === "node_modules") return null
   if (
     directory === "client" ||
     directory === "server" ||
@@ -223,24 +321,19 @@ function runtimeForPath(path: string): PluginRuntime | null {
     return directory
 
   const filename = parts.at(-1)
-  if (/^index\.client\.(?:ts|tsx)$/.test(filename ?? "")) return "client"
-  if (/^index\.server\.(?:ts|tsx)$/.test(filename ?? "")) return "server"
-  return null
+  if (parts.length === 1 && /^index\.client\.(?:ts|tsx)$/.test(filename ?? ""))
+    return "client"
+  if (parts.length === 1 && /^index\.server\.(?:ts|tsx)$/.test(filename ?? ""))
+    return "server"
+  return "invalid"
 }
 
-function importedRuntime(
+function importedLocation(
   path: string,
   specifier: string
-): PluginRuntime | null {
-  if (specifier.startsWith("."))
-    return runtimeForPath(normalize(join(dirname(path), specifier)))
-
-  const directory = specifier.split("/")[0]
-  return directory === "client" ||
-    directory === "server" ||
-    directory === "shared"
-    ? directory
-    : null
+): PluginModuleLocation | null {
+  if (!specifier.startsWith(".")) return null
+  return runtimeForPath(normalize(join(dirname(path), specifier)))
 }
 
 function crossesRuntimeBoundary(
@@ -252,32 +345,89 @@ function crossesRuntimeBoundary(
   return target === "client"
 }
 
+function runtimeSpecifierViolation(
+  source: PluginRuntime,
+  specifier: string
+): "unsupported-sdk-import" | "runtime-module-import" | null {
+  if (
+    (specifier === "@getpaseo/plugin" ||
+      specifier.startsWith("@getpaseo/plugin/") ||
+      specifier === "@paseo/plugin" ||
+      specifier.startsWith("@paseo/plugin/")) &&
+    !SUPPORTED_SDK[specifier]
+  )
+    return "unsupported-sdk-import"
+  if (
+    source !== "server" &&
+    (isBuiltin(specifier) || specifier === "@types/node")
+  )
+    return "runtime-module-import"
+  if (source !== "server" && SERVER_ONLY_SDK[specifier])
+    return "runtime-module-import"
+  if (
+    source !== "client" &&
+    (CLIENT_ONLY_SDK[specifier] || CLIENT_ONLY_MODULE.test(specifier))
+  )
+    return "runtime-module-import"
+  return null
+}
+
 function scanBoundaries(
   content: string,
   path: string,
   findings: SecurityFinding[]
 ) {
-  if (!/\.(?:[cm]?[jt]s|[jt]sx)$/.test(path)) return
-  const source = runtimeForPath(path)
-  if (!source) return
+  if (!CODE_MODULE.test(path)) return
+  const location = runtimeForPath(path)
+  if (!location || location === "invalid") return
 
-  const imports = ts.preProcessFile(content, true, true).importedFiles
-  if (
-    imports.some(({ fileName }) => {
-      const target = importedRuntime(path, fileName)
-      return target !== null && crossesRuntimeBoundary(source, target)
-    })
-  )
-    findings.push(
-      finding(
-        "boundary",
-        "cross-runtime-import",
-        "high",
-        true,
-        path,
-        "cross-runtime import boundary violated"
+  const imports = ts.preProcessFile(content, true, true)
+  const specifiers = [
+    ...imports.importedFiles.map(({ fileName }) => fileName),
+    ...imports.typeReferenceDirectives.map(
+      ({ fileName }) =>
+        `@types/${fileName.replace(/^@/, "").replace("/", "__")}`
+    ),
+  ]
+  for (const specifier of specifiers) {
+    const ruleId = runtimeSpecifierViolation(location, specifier)
+    if (ruleId) {
+      findings.push(
+        finding(
+          "boundary",
+          ruleId,
+          "high",
+          true,
+          path,
+          `${specifier} cannot be imported from ${location} code`
+        )
       )
-    )
+      continue
+    }
+    const target = importedLocation(path, specifier)
+    if (target === "invalid")
+      findings.push(
+        finding(
+          "boundary",
+          "invalid-module-location",
+          "high",
+          true,
+          path,
+          `plugin module import must stay under client/, server/, or shared/: ${specifier}`
+        )
+      )
+    else if (target && crossesRuntimeBoundary(location, target))
+      findings.push(
+        finding(
+          "boundary",
+          "cross-runtime-import",
+          "high",
+          true,
+          path,
+          `${location} code cannot import ${target} code: ${specifier}`
+        )
+      )
+  }
 }
 function finding(
   tool: string,

--- a/scripts/plugin-security/static-scan.ts
+++ b/scripts/plugin-security/static-scan.ts
@@ -1,7 +1,15 @@
 #!/usr/bin/env bun
-import { lstatSync, readdirSync, readFileSync } from "node:fs"
+import { existsSync, lstatSync, opendirSync, readFileSync } from "node:fs"
 import { isBuiltin } from "node:module"
-import { dirname, join, normalize, relative, resolve } from "node:path"
+import {
+  dirname,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+  resolve,
+  win32,
+} from "node:path"
 import * as semver from "semver"
 import * as ts from "typescript"
 import type { SecurityFinding } from "./shared.ts"
@@ -27,7 +35,8 @@ type ScanState = {
   manifest: boolean
   clientEntry: boolean
   serverEntry: boolean
-  legacyEntry: boolean
+  legacyEntry: string | null
+  sources: Map<string, string>
 }
 
 const PLUGIN_ID = /^[a-z][a-z0-9-]*$/
@@ -51,6 +60,49 @@ const SUPPORTED_SDK: Record<string, true> = {
 }
 const CLIENT_ONLY_MODULE =
   /^(?:(?:@types\/)?react(?:-dom|-native)?|use-sync-external-store|@tanstack\/react-query)(?:\/|$)/
+type ImportResolver = (
+  specifier: string,
+  importer: string
+) => string | undefined
+
+function createImportResolver(directory: string): ImportResolver {
+  const configFile = ts.findConfigFile(directory, ts.sys.fileExists)
+  const config = configFile
+    ? ts.getParsedCommandLineOfConfigFile(
+        configFile,
+        {},
+        {
+          ...ts.sys,
+          onUnRecoverableConfigFileDiagnostic(diagnostic) {
+            throw new Error(
+              ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")
+            )
+          },
+        }
+      )
+    : undefined
+  const options = {
+    ...config?.options,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    allowJs: true,
+  }
+  const cache = ts.createModuleResolutionCache(
+    directory,
+    (file) => file,
+    options
+  )
+  return (specifier, importer) => {
+    const resolvedModule = ts.resolveModuleName(
+      specifier,
+      importer,
+      options,
+      ts.sys,
+      cache
+    ).resolvedModule
+    return resolvedModule?.resolvedFileName
+  }
+}
 
 export function scanStaticFiles(input: StaticScanInput): StaticScanOutput {
   const root = resolve(input.root, input.pluginPath ?? ".")
@@ -61,11 +113,33 @@ export function scanStaticFiles(input: StaticScanInput): StaticScanOutput {
     manifest: false,
     clientEntry: false,
     serverEntry: false,
-    legacyEntry: false,
+    legacyEntry: null,
+    sources: new Map(),
   }
   const findings: SecurityFinding[] = []
   const buildCommands: string[][] = []
-  walk(root, root, 0, state, findings, buildCommands, input.registryId)
+  const resolveImport = createImportResolver(root)
+  walk(
+    root,
+    root,
+    0,
+    state,
+    findings,
+    buildCommands,
+    resolveImport,
+    input.registryId
+  )
+  const checkedImports = new Set<string>()
+  for (const [path, content] of state.sources)
+    scanBoundaries(
+      content,
+      path,
+      root,
+      resolveImport,
+      findings,
+      state.sources,
+      checkedImports
+    )
   if (!state.manifest)
     findings.push(
       finding(
@@ -77,17 +151,30 @@ export function scanStaticFiles(input: StaticScanInput): StaticScanOutput {
         "plugin manifest is missing"
       )
     )
-  if (!state.clientEntry && !state.serverEntry && !state.legacyEntry)
-    findings.push(
-      finding(
-        "entrypoint",
-        "missing",
-        "high",
-        true,
-        ".",
-        "plugin has no Paseo 0.8 runtime entry"
+  if (!state.clientEntry && !state.serverEntry) {
+    if (state.legacyEntry)
+      findings.push(
+        finding(
+          "entrypoint",
+          "legacy-index",
+          "high",
+          true,
+          state.legacyEntry,
+          "legacy-only index.ts or index.tsx is rejected"
+        )
       )
-    )
+    else
+      findings.push(
+        finding(
+          "entrypoint",
+          "missing",
+          "high",
+          true,
+          ".",
+          "plugin has no Paseo 0.8 runtime entry"
+        )
+      )
+  }
   if (state.incomplete)
     findings.push(
       finding(
@@ -109,60 +196,82 @@ function walk(
   state: ScanState,
   findings: SecurityFinding[],
   buildCommands: string[][],
+  resolveImport: ImportResolver,
   registryId?: string
-) {
+): boolean {
   if (depth > MAX_DEPTH) {
     state.incomplete = true
-    return
+    return false
   }
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    const rel = relative(base, full) || entry.name
-    if (entry.isDirectory() && entry.name === ".git") continue
-    if (entry.isSymbolicLink()) {
-      state.incomplete = true
-      findings.push(
-        finding("scanner", "symlink", "high", true, rel, "symlink rejected")
-      )
-      continue
-    }
-    const meta = lstatSync(full)
-    if (meta.size > MAX_BYTES) {
-      state.incomplete = true
-      findings.push(
-        finding(
-          "scanner",
-          "size-limit",
-          "high",
-          true,
-          rel,
-          "file exceeds size budget"
+  const directory = opendirSync(dir)
+  try {
+    for (
+      let entry = directory.readSync();
+      entry !== null;
+      entry = directory.readSync()
+    ) {
+      const full = join(dir, entry.name)
+      const rel = relative(base, full) || entry.name
+      if (entry.isDirectory() && entry.name === ".git") continue
+      if (entry.isSymbolicLink()) {
+        state.incomplete = true
+        findings.push(
+          finding("scanner", "symlink", "high", true, rel, "symlink rejected")
         )
-      )
-      continue
+        continue
+      }
+      const meta = lstatSync(full)
+      if (entry.isDirectory()) {
+        if (
+          !walk(
+            base,
+            full,
+            depth + 1,
+            state,
+            findings,
+            buildCommands,
+            resolveImport,
+            registryId
+          )
+        )
+          return false
+        continue
+      }
+      if (!entry.isFile()) continue
+      if (meta.size > MAX_BYTES) {
+        state.incomplete = true
+        findings.push(
+          finding(
+            "scanner",
+            "size-limit",
+            "high",
+            true,
+            rel,
+            "file exceeds size budget"
+          )
+        )
+        return false
+      }
+      if (state.files >= MAX_FILES || state.bytes + meta.size > MAX_BYTES) {
+        state.incomplete = true
+        return false
+      }
+      state.files += 1
+      state.bytes += meta.size
+      const content = readFileSync(full, "utf8")
+      if (rel === "paseo-plugin.json") {
+        state.manifest = true
+        validateManifest(content, rel, registryId, findings, buildCommands)
+      }
+      const entryMatch = RUNTIME_ENTRY.exec(rel)
+      if (entryMatch?.[1] === "client") state.clientEntry = true
+      if (entryMatch?.[1] === "server") state.serverEntry = true
+      if (LEGACY_ENTRY.test(rel)) state.legacyEntry = rel
+      if (CODE_MODULE.test(rel)) state.sources.set(rel, content)
     }
-    if (entry.isDirectory()) {
-      walk(base, full, depth + 1, state, findings, buildCommands, registryId)
-      continue
-    }
-    if (!entry.isFile()) continue
-    state.files += 1
-    if (state.files > MAX_FILES) state.incomplete = true
-    const content = readFileSync(full, "utf8")
-    state.bytes += meta.size
-    if (state.bytes > MAX_BYTES) state.incomplete = true
-    if (rel === "paseo-plugin.json") {
-      state.manifest = true
-      validateManifest(content, rel, registryId, findings, buildCommands)
-    }
-    const entryMatch = RUNTIME_ENTRY.exec(rel)
-    if (entryMatch?.[1] === "client") state.clientEntry = true
-    if (entryMatch?.[1] === "server") state.serverEntry = true
-    if (LEGACY_ENTRY.test(rel)) {
-      state.legacyEntry = true
-      validateEntrypoint(entry.name, rel, findings)
-    }
-    scanBoundaries(content, rel, findings)
+    return true
+  } finally {
+    directory.closeSync()
   }
 }
 
@@ -288,31 +397,12 @@ function validateManifest(
     )
   }
 }
-function validateEntrypoint(
-  name: string,
-  path: string,
-  findings: SecurityFinding[]
-) {
-  if (name === "index.ts" || name === "index.tsx")
-    findings.push(
-      finding(
-        "entrypoint",
-        "legacy-index",
-        "high",
-        true,
-        path,
-        "legacy-only index.ts is rejected"
-      )
-    )
-}
 type PluginRuntime = "client" | "server" | "shared"
 type PluginModuleLocation = PluginRuntime | "invalid"
 
-function runtimeForPath(path: string): PluginModuleLocation | null {
+function runtimeOwnerForPath(path: string): PluginRuntime | null {
   const parts = path.split(/[\\/]/)
-  if (parts[0] === "..") return "invalid"
-  const directory = parts.length > 1 ? parts[0] : undefined
-  if (directory === "node_modules") return null
+  const directory = parts[0]
   if (
     directory === "client" ||
     directory === "server" ||
@@ -325,15 +415,92 @@ function runtimeForPath(path: string): PluginModuleLocation | null {
     return "client"
   if (parts.length === 1 && /^index\.server\.(?:ts|tsx)$/.test(filename ?? ""))
     return "server"
-  return "invalid"
+  return null
 }
 
-function importedLocation(
+function runtimeForPath(path: string): PluginModuleLocation | null {
+  const parts = path.split(/[\\/]/)
+  if (parts[0] === "..") return "invalid"
+  if (parts.includes("node_modules")) return null
+  return runtimeOwnerForPath(path) ?? "invalid"
+}
+
+function containsPath(directory: string, path: string): boolean {
+  const nested = relative(directory, path)
+  return nested === "" || (!nested.startsWith("..") && !isAbsolute(nested))
+}
+
+function dependencyName(specifier: string): string {
+  const segments = specifier.split("/")
+  return specifier.startsWith("@")
+    ? segments.slice(0, 2).join("/")
+    : segments[0]
+}
+
+function isExternalDependency(
+  base: string,
+  specifier: string,
+  resolvedPath: string
+): boolean {
+  const expectedName = dependencyName(specifier)
+  for (
+    let directory = dirname(resolvedPath);
+    ;
+    directory = dirname(directory)
+  ) {
+    const manifestPath = join(directory, "package.json")
+    if (existsSync(manifestPath)) {
+      try {
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+          name?: unknown
+        }
+        if (manifest.name === expectedName)
+          return (
+            !containsPath(base, directory) && !containsPath(directory, base)
+          )
+      } catch {
+        return false
+      }
+    }
+    const parent = dirname(directory)
+    if (parent === directory) return false
+  }
+}
+
+type ImportedModule = {
+  location: PluginModuleLocation | null
+  path?: string
+}
+
+function importedModule(
+  base: string,
   path: string,
-  specifier: string
-): PluginModuleLocation | null {
-  if (!specifier.startsWith(".")) return null
-  return runtimeForPath(normalize(join(dirname(path), specifier)))
+  specifier: string,
+  resolveImport: ImportResolver
+): ImportedModule {
+  if (win32.isAbsolute(specifier) && !isAbsolute(specifier))
+    return { location: "invalid" }
+  const resolvedImport = specifier.startsWith(".")
+    ? resolveImport(specifier, resolve(base, path))
+    : isAbsolute(specifier)
+      ? specifier
+      : resolveImport(specifier, resolve(base, path))
+  const importedPath = resolvedImport
+    ? relative(base, resolvedImport)
+    : specifier.startsWith(".")
+      ? normalize(join(dirname(path), specifier))
+      : undefined
+  if (!importedPath) return { location: null }
+  const location = runtimeForPath(importedPath)
+  if (
+    location === "invalid" &&
+    !specifier.startsWith(".") &&
+    !isAbsolute(specifier) &&
+    resolvedImport &&
+    isExternalDependency(base, specifier, resolvedImport)
+  )
+    return { location: null }
+  return { location, path: importedPath }
 }
 
 function crossesRuntimeBoundary(
@@ -354,7 +521,7 @@ function runtimeSpecifierViolation(
       specifier.startsWith("@getpaseo/plugin/") ||
       specifier === "@paseo/plugin" ||
       specifier.startsWith("@paseo/plugin/")) &&
-    !SUPPORTED_SDK[specifier]
+    !Object.hasOwn(SUPPORTED_SDK, specifier)
   )
     return "unsupported-sdk-import"
   if (
@@ -362,35 +529,64 @@ function runtimeSpecifierViolation(
     (isBuiltin(specifier) || specifier === "@types/node")
   )
     return "runtime-module-import"
-  if (source !== "server" && SERVER_ONLY_SDK[specifier])
+  if (source !== "server" && Object.hasOwn(SERVER_ONLY_SDK, specifier))
     return "runtime-module-import"
   if (
     source !== "client" &&
-    (CLIENT_ONLY_SDK[specifier] || CLIENT_ONLY_MODULE.test(specifier))
+    (Object.hasOwn(CLIENT_ONLY_SDK, specifier) ||
+      CLIENT_ONLY_MODULE.test(specifier))
   )
     return "runtime-module-import"
   return null
 }
 
+function isHostProvidedModule(specifier: string): boolean {
+  return (
+    Object.hasOwn(SUPPORTED_SDK, specifier) ||
+    /^(?:zod|react|react-native|@tanstack\/react-query)(?:\/|$)/.test(
+      specifier
+    ) ||
+    isBuiltin(specifier) ||
+    specifier === "@types/node"
+  )
+}
+
 function scanBoundaries(
   content: string,
   path: string,
-  findings: SecurityFinding[]
+  base: string,
+  resolveImport: ImportResolver,
+  findings: SecurityFinding[],
+  sources: Map<string, string>,
+  checked: Set<string>,
+  inheritedOwner?: PluginRuntime
 ) {
   if (!CODE_MODULE.test(path)) return
   const location = runtimeForPath(path)
-  if (!location || location === "invalid") return
+  if (location === "invalid") return
+  const owner = location ?? inheritedOwner ?? runtimeOwnerForPath(path)
+  if (!owner) return
+  const visitKey = `${owner}:${path}`
+  if (checked.has(visitKey)) return
+  checked.add(visitKey)
 
   const imports = ts.preProcessFile(content, true, true)
   const specifiers = [
     ...imports.importedFiles.map(({ fileName }) => fileName),
-    ...imports.typeReferenceDirectives.map(
-      ({ fileName }) =>
-        `@types/${fileName.replace(/^@/, "").replace("/", "__")}`
+    ...imports.referencedFiles.map(({ fileName }) =>
+      fileName.startsWith(".") ||
+      isAbsolute(fileName) ||
+      win32.isAbsolute(fileName)
+        ? fileName
+        : `./${fileName}`
     ),
+    ...imports.typeReferenceDirectives.flatMap(({ fileName }) => [
+      fileName,
+      `@types/${fileName.replace(/^@/, "").replace("/", "__")}`,
+    ]),
   ]
   for (const specifier of specifiers) {
-    const ruleId = runtimeSpecifierViolation(location, specifier)
+    const ruleId = runtimeSpecifierViolation(owner, specifier)
     if (ruleId) {
       findings.push(
         finding(
@@ -399,13 +595,14 @@ function scanBoundaries(
           "high",
           true,
           path,
-          `${specifier} cannot be imported from ${location} code`
+          `${specifier} cannot be imported from ${owner} code`
         )
       )
       continue
     }
-    const target = importedLocation(path, specifier)
-    if (target === "invalid")
+    if (isHostProvidedModule(specifier)) continue
+    const imported = importedModule(base, path, specifier, resolveImport)
+    if (imported.location === "invalid")
       findings.push(
         finding(
           "boundary",
@@ -416,7 +613,10 @@ function scanBoundaries(
           `plugin module import must stay under client/, server/, or shared/: ${specifier}`
         )
       )
-    else if (target && crossesRuntimeBoundary(location, target))
+    else if (
+      imported.location &&
+      crossesRuntimeBoundary(owner, imported.location)
+    )
       findings.push(
         finding(
           "boundary",
@@ -424,9 +624,23 @@ function scanBoundaries(
           "high",
           true,
           path,
-          `${location} code cannot import ${target} code: ${specifier}`
+          `${owner} code cannot import ${imported.location} code: ${specifier}`
         )
       )
+    if (imported.location === null && imported.path) {
+      const dependency = sources.get(imported.path)
+      if (dependency !== undefined)
+        scanBoundaries(
+          dependency,
+          imported.path,
+          base,
+          resolveImport,
+          findings,
+          sources,
+          checked,
+          owner
+        )
+    }
   }
 }
 function finding(


### PR DESCRIPTION
## Summary
- enforce Paseo 0.8 manifest IDs, requirements, strict keys, and runtime entrypoints
- reject cross-runtime, Node/client, private, retired, and unknown SDK imports using the v0.8 ownership rules
- add report guidance and regression coverage for every new finding

## Verification
- `bun run security:test` (29 tests passed)
- `bun run check:app`
- `bunx tsc --noEmit`
- local `plugin/` smoke scan returned zero findings