### PR TITLE
Add time-since, setup-monitor, and workspace-links

### DIFF
--- a/registry/setup-monitor.json
+++ b/registry/setup-monitor.json
@@ -1,0 +1,6 @@
+{
+  "repo": "stevecastaneda/paseo-plugins",
+  "path": "setup-monitor",
+  "categories": ["monitoring", "productivity"],
+  "submittedBy": "stevecastaneda"
+}

--- a/registry/time-since.json
+++ b/registry/time-since.json
@@ -1,0 +1,6 @@
+{
+  "repo": "stevecastaneda/paseo-plugins",
+  "path": "time-since",
+  "categories": ["productivity"],
+  "submittedBy": "stevecastaneda"
+}

--- a/registry/workspace-links.json
+++ b/registry/workspace-links.json
@@ -1,0 +1,9 @@
+{
+  "repo": "stevecastaneda/paseo-plugins",
+  "path": "workspace-links",
+  "categories": ["productivity"],
+  "caveats": [
+    "Links open in the default browser on the daemon host, not the device viewing Paseo"
+  ],
+  "submittedBy": "stevecastaneda"
+}


### PR DESCRIPTION
Adds three plugins from [stevecastaneda/paseo-plugins](https://github.com/stevecastaneda/paseo-plugins):

- **time-since** — composer pill for elapsed time since the last chat message
- **setup-monitor** — live `worktree.setup` progress and logs in Explorer
- **workspace-links** — workspace URLs from `workspace-links.json`

Each lives in its own subdirectory, so the registry entries set `path`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Setup Monitor plugin to the registry under monitoring and productivity.
  - Added the Time Since plugin to the productivity registry.
  - Added the Workspace Links plugin to the productivity registry, with a note about links opening in the daemon host’s default browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->