### PR TITLE
Add tell-agent

### DIFF
--- a/registry/tell-agent.json
+++ b/registry/tell-agent.json
@@ -1,0 +1,7 @@
+{
+  "repo": "omercnet/paseo-plugins",
+  "path": "tell-agent",
+  "categories": ["productivity", "orchestration"],
+  "caveats": ["Requires Paseo 0.8.x"],
+  "submittedBy": "omercnet"
+}


### PR DESCRIPTION
## Summary
- register the `tell-agent` plugin from `omercnet/paseo-plugins/tell-agent`
- categorize it under productivity and orchestration
- declare its Paseo 0.8.x requirement

## Validation
- `bun run registry:validate`
- 48 registry entries validated successfully
