### PR TITLE
fix: restore mobile catalog layout

### DIFF
--- a/src/components/catalog-sidebar.tsx
+++ b/src/components/catalog-sidebar.tsx
@@ -37,7 +37,7 @@ export function CatalogSidebar({
   onPlatformChange,
 }: CatalogSidebarProps) {
   return (
-    <aside className="flex flex-col gap-3 bg-card p-3 lg:sticky lg:top-20 lg:w-1/3 lg:shrink-0 lg:self-start">
+    <aside className="flex flex-col gap-3 bg-card p-3 lg:sticky lg:top-20 lg:order-last lg:w-1/3 lg:shrink-0 lg:self-start">
       <div className="relative">
         <InputGroup>
           <InputGroupAddon align="inline-start">

--- a/src/components/copy-command.tsx
+++ b/src/components/copy-command.tsx
@@ -15,11 +15,13 @@ export function CopyCommand({
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-3 border border-border bg-muted px-4 py-3",
+        "flex min-w-0 max-w-full items-center justify-between gap-3 border border-border bg-muted px-4 py-3",
         className
       )}
     >
-      <code className="overflow-x-auto whitespace-pre text-sm">{command}</code>
+      <code className="min-w-0 flex-1 overflow-x-auto whitespace-pre text-sm">
+        {command}
+      </code>
       <Button
         variant="outline"
         size="icon-sm"

--- a/src/components/install-callout.tsx
+++ b/src/components/install-callout.tsx
@@ -11,7 +11,7 @@ export function InstallCallout({ plugin }: { plugin: PluginRecord }) {
       </h2>
       <CopyCommand
         command={getInstallCommand(plugin)}
-        className="mx-auto w-fit"
+        className="mx-auto w-full sm:w-fit"
       />
     </div>
   )

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -149,8 +149,8 @@ function App() {
     : `${plugins.length} plugin${plugins.length === 1 ? "" : "s"} generated from their source repos.`
 
   return (
-    <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 pb-20">
-      <div className="mx-auto flex max-w-2xl flex-col gap-4 px-6 pt-16 pb-2 text-center">
+    <div className="mx-auto flex max-w-6xl flex-col gap-3 px-4 pb-20 sm:px-6">
+      <div className="mx-auto flex w-full min-w-0 max-w-2xl flex-col gap-4 px-0 pt-16 pb-2 text-center sm:px-6">
         <div className="mx-auto flex items-center gap-1.5 text-foreground/50 text-xs">
           <span className="size-1.5 rounded-full bg-primary" />
           Community-run unofficial directory
@@ -171,6 +171,29 @@ function App() {
 
       <p className="text-foreground/60 text-sm">{summary}</p>
       <div className="mx-auto flex w-full flex-col gap-8 lg:flex-row lg:items-start">
+        <CatalogSidebar
+          search={search}
+          totalCount={plugins.length}
+          categories={categories}
+          categoryCounts={categoryCounts}
+          platforms={platformsWithResults}
+          platformCounts={platformCounts}
+          onQueryChange={(q) =>
+            navigate({
+              search: (prev) => ({ ...prev, q, page: 1 }),
+              replace: true,
+            })
+          }
+          onSortChange={(sort) =>
+            navigate({ search: (prev) => ({ ...prev, sort, page: 1 }) })
+          }
+          onCategoryChange={(category) =>
+            navigate({ search: (prev) => ({ ...prev, category, page: 1 }) })
+          }
+          onPlatformChange={(platform) =>
+            navigate({ search: (prev) => ({ ...prev, platform, page: 1 }) })
+          }
+        />
         <div className="min-w-0 flex-1">
           {showFeatured ? (
             <div className="flex flex-col gap-8">
@@ -197,30 +220,6 @@ function App() {
             totalCount={sorted.length}
           />
         </div>
-
-        <CatalogSidebar
-          search={search}
-          totalCount={plugins.length}
-          categories={categories}
-          categoryCounts={categoryCounts}
-          platforms={platformsWithResults}
-          platformCounts={platformCounts}
-          onQueryChange={(q) =>
-            navigate({
-              search: (prev) => ({ ...prev, q, page: 1 }),
-              replace: true,
-            })
-          }
-          onSortChange={(sort) =>
-            navigate({ search: (prev) => ({ ...prev, sort, page: 1 }) })
-          }
-          onCategoryChange={(category) =>
-            navigate({ search: (prev) => ({ ...prev, category, page: 1 }) })
-          }
-          onPlatformChange={(platform) =>
-            navigate({ search: (prev) => ({ ...prev, platform, page: 1 }) })
-          }
-        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Problem

PR #63 made the catalog wider than phone viewports because the install command imposed its intrinsic width on the hero. It also placed catalog filters after every result section on mobile.

## Changes

- constrain the install command and scroll its code without pushing the page wider
- make the hero and page gutters responsive at phone widths
- place catalog filters before results on mobile while keeping the sidebar on the right at desktop widths

## Screenshots

| Before | After |
| --- | --- |
| ![Before mobile catalog](https://github.com/user-attachments/assets/cb685239-625c-4343-8e67-51a4eeae4a3e) | ![After mobile catalog](https://github.com/user-attachments/assets/296e40d5-9152-4f54-b197-ab3631d85613) |

Both screenshots use a 390 × 844 viewport.

## Verification

- Browser-checked direct loads at 320, 375, 390, 430, 768, 1024, and 1440 px: document width matches viewport at every breakpoint
- Browser-checked the install command remains fully contained with an internal scroller on narrow screens
- Browser-checked filters precede results on mobile and remain right-aligned on desktop
- `bun run check:app`
- `bun run typecheck`
- `bun run build`