### PR TITLE
fix(plugin): run the Paseo CLI through cmd.exe on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,18 @@ jobs:
         run: bun run build:generated
 
   plugin:
-    name: Plugin
+    name: Plugin (${{ matrix.os }})
     needs: changes
     if: needs.changes.outputs.plugin == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    strategy:
+      # The plugin is the only thing here that shells out to the Paseo CLI,
+      # and it builds a different invocation per platform (cmd.exe on
+      # Windows), so those branches have to run somewhere.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -118,6 +125,8 @@ jobs:
           cache: npm
           cache-dependency-path: plugin/package-lock.json
 
+      # plugin/ has no Vitest config of its own, so `npm run test` resolves
+      # the root one and needs Vitest installed there on every runner.
       - name: Install root dependencies
         run: bun install --frozen-lockfile
 
@@ -125,7 +134,10 @@ jobs:
         working-directory: plugin
         run: npm ci
 
+      # Formatting is platform-independent, and a Windows checkout's line
+      # endings would make Biome disagree with itself.
       - name: Check with Biome
+        if: runner.os == 'Linux'
         run: bun run check:plugin
 
       - name: Typecheck

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -657,56 +657,70 @@ describe("Paseo CLI invocation", () => {
       executable: "paseo",
       args: ["plugin", "ls", "--json"],
       env: { PATH: "/usr/bin" },
+      windowsVerbatimArguments: false,
     })
   })
 
   it("quotes the npm command shim invocation on Windows", () => {
-    const invocation = buildPaseoInvocation(
-      ["plugin", "update", "review", "--json"],
-      "win32"
-    )
-
-    expect(invocation.args).toEqual([
-      "/d",
-      "/s",
-      "/c",
-      '""paseo" "plugin" "update" "review" "--json""',
-    ])
+    // The extra outer pair and the verbatim flag are only correct together:
+    // cmd.exe /s eats that pair, and node would rewrite it as \" without the
+    // flag. Assert both, since no CI runner executes this branch.
+    expect(
+      buildPaseoInvocation(["plugin", "update", "review", "--json"], "win32", {
+        ComSpec: "C:\\Windows\\system32\\cmd.exe",
+      })
+    ).toEqual({
+      executable: "C:\\Windows\\system32\\cmd.exe",
+      args: ["/d", "/s", "/c", '""paseo" "plugin" "update" "review" "--json""'],
+      env: { ComSpec: "C:\\Windows\\system32\\cmd.exe" },
+      windowsVerbatimArguments: true,
+    })
   })
 
   it("runs the shim cmd.exe resolves, with the arguments intact", async () => {
     // Asserting the argv is only half the contract: cmd.exe — not node —
     // decides how the command string splits, so the pair has to run for real.
     const binDir = await mkdtemp(join(tmpdir(), "paseo-cli-invocation-"))
-    const isWindows = process.platform === "win32"
-    const shim = join(binDir, isWindows ? "paseo.cmd" : "paseo")
-    // Report the arguments the way a real CLI process receives them, so the
-    // assertion covers node's parsing of what cmd.exe handed over instead of
-    // the raw command text.
-    const report = `console.log(JSON.stringify(process.argv.slice(1)))`
-    await writeFile(
-      shim,
-      isWindows
-        ? `@echo off\r\nnode -e "${report}" %*\r\n`
-        : `#!/bin/sh\nexec node -e '${report}' "$@"\n`,
-      "utf8"
-    )
-    if (!isWindows) await chmod(shim, 0o755)
     const originalPath = process.env.PATH
-    process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`
     try {
-      const { stdout } = await execPaseo(["plugin", "ls", "--json"], 30_000)
+      const isWindows = process.platform === "win32"
+      const shim = join(binDir, isWindows ? "paseo.cmd" : "paseo")
+      // Report the arguments the way a real CLI process receives them, so the
+      // assertion covers node's parsing of what cmd.exe handed over instead of
+      // the raw command text.
+      const report = `console.log(JSON.stringify(process.argv.slice(1)))`
+      const node = `"${process.execPath}"`
+      await writeFile(
+        shim,
+        isWindows
+          ? `@echo off\r\n${node} -e "${report}" %*\r\n`
+          : `#!/bin/sh\nexec ${node} -e '${report}' "$@"\n`,
+        "utf8"
+      )
+      if (!isWindows) await chmod(shim, 0o755)
+      process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`
+
+      const { stdout } = await execPaseo(["plugin", "ls", "--json"], 10_000)
 
       expect(JSON.parse(stdout)).toEqual(["plugin", "ls", "--json"])
     } finally {
-      process.env.PATH = originalPath
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
       await rm(binDir, { recursive: true, force: true })
     }
-  }, 30_000)
+  }, 20_000)
 
   it("rejects Windows command metacharacters", () => {
     expect(() =>
       buildPaseoInvocation(["plugin", "update", "review&calc"], "win32")
+    ).toThrow("unsupported Windows shell characters")
+  })
+
+  it("rejects a token that would escape its own closing quote", () => {
+    // `"review\"` leaves the closing quote escaped for the argv parser behind
+    // cmd.exe, which then swallows the following argument.
+    expect(() =>
+      buildPaseoInvocation(["plugin", "update", "review\\", "--json"], "win32")
     ).toThrow("unsupported Windows shell characters")
   })
 })

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -1,3 +1,6 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { InstalledPlugin } from "../shared/directory"
 import {
@@ -8,6 +11,7 @@ import {
 import {
   buildInstallArgs,
   buildPaseoInvocation,
+  execPaseo,
   inspectUpdateStatus,
   installDirectoryPlugin,
   listDirectory,
@@ -666,9 +670,39 @@ describe("Paseo CLI invocation", () => {
       "/d",
       "/s",
       "/c",
-      '"paseo" "plugin" "update" "review" "--json"',
+      '""paseo" "plugin" "update" "review" "--json""',
     ])
   })
+
+  it("runs the shim cmd.exe resolves, with the arguments intact", async () => {
+    // Asserting the argv is only half the contract: cmd.exe — not node —
+    // decides how the command string splits, so the pair has to run for real.
+    const binDir = await mkdtemp(join(tmpdir(), "paseo-cli-invocation-"))
+    const isWindows = process.platform === "win32"
+    const shim = join(binDir, isWindows ? "paseo.cmd" : "paseo")
+    // Report the arguments the way a real CLI process receives them, so the
+    // assertion covers node's parsing of what cmd.exe handed over instead of
+    // the raw command text.
+    const report = `console.log(JSON.stringify(process.argv.slice(1)))`
+    await writeFile(
+      shim,
+      isWindows
+        ? `@echo off\r\nnode -e "${report}" %*\r\n`
+        : `#!/bin/sh\nexec node -e '${report}' "$@"\n`,
+      "utf8"
+    )
+    if (!isWindows) await chmod(shim, 0o755)
+    const originalPath = process.env.PATH
+    process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`
+    try {
+      const { stdout } = await execPaseo(["plugin", "ls", "--json"], 30_000)
+
+      expect(JSON.parse(stdout)).toEqual(["plugin", "ls", "--json"])
+    } finally {
+      process.env.PATH = originalPath
+      await rm(binDir, { recursive: true, force: true })
+    }
+  }, 30_000)
 
   it("rejects Windows command metacharacters", () => {
     expect(() =>

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -94,18 +94,25 @@ export function buildPaseoInvocation(
     }
     return `"${value}"`
   })
+  // cmd.exe /s strips one outer pair of quotes, and only after that does it
+  // resolve the first token as a command. Without the extra pair the quoted
+  // name survives as `paseo" "plugin` and the shim is never found.
   return {
     executable: process.env.ComSpec || "cmd.exe",
-    args: ["/d", "/s", "/c", tokens.join(" ")],
+    args: ["/d", "/s", "/c", `"${tokens.join(" ")}"`],
     env: childEnv,
   }
 }
 
-async function execPaseo(args: readonly string[], timeout: number) {
+export async function execPaseo(args: readonly string[], timeout: number) {
   const invocation = buildPaseoInvocation(args)
   return execFileAsync(invocation.executable, invocation.args, {
     timeout,
     env: invocation.env,
+    // Node re-escapes the quotes above as \" unless it hands the command
+    // string to cmd.exe verbatim, and cmd.exe has no \" escape: it looked for
+    // a command literally named \"paseo\".
+    windowsVerbatimArguments: process.platform === "win32",
   })
 }
 

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -73,20 +73,34 @@ export function buildPaseoInvocation(
   args: readonly string[],
   platform = process.platform,
   env = process.env
-): { executable: string; args: string[]; env: NodeJS.ProcessEnv } {
+): {
+  executable: string
+  args: string[]
+  env: NodeJS.ProcessEnv
+  windowsVerbatimArguments: boolean
+} {
   const childEnv = { ...env }
   // A plugin subprocess launched by the packaged Electron app inherits this.
   // Passing it back to the AppImage makes Electron treat "plugin" as a Node
   // entrypoint instead of dispatching the Paseo CLI.
   delete childEnv.ELECTRON_RUN_AS_NODE
   if (platform !== "win32") {
-    return { executable: "paseo", args: [...args], env: childEnv }
+    return {
+      executable: "paseo",
+      args: [...args],
+      env: childEnv,
+      windowsVerbatimArguments: false,
+    }
   }
   const tokens = ["paseo", ...args].map((value) => {
+    // Every token is passed as its own quoted argument, so it must not be
+    // able to close that quote: no literal `"`, and no backslash, since an
+    // odd trailing run of them escapes the closing quote for the argv parser
+    // downstream of cmd.exe and merges the next token into this one.
     if (
       value.includes(String.fromCharCode(0)) ||
       value.includes('"') ||
-      /[\r\n&|<>()^%!]/.test(value)
+      /[\\\r\n&|<>()^%!]/.test(value)
     ) {
       throw new Error(
         "Paseo CLI argument contains unsupported Windows shell characters"
@@ -96,11 +110,15 @@ export function buildPaseoInvocation(
   })
   // cmd.exe /s strips one outer pair of quotes, and only after that does it
   // resolve the first token as a command. Without the extra pair the quoted
-  // name survives as `paseo" "plugin` and the shim is never found.
+  // name survives as `paseo" "plugin` and the shim is never found. The pair
+  // only reaches cmd.exe intact when the command string is passed verbatim,
+  // so the two travel together. This is the same shape Node itself builds
+  // for `shell: true` on Windows (lib/child_process.js, normalizeSpawnArguments).
   return {
-    executable: process.env.ComSpec || "cmd.exe",
+    executable: env.ComSpec || "cmd.exe",
     args: ["/d", "/s", "/c", `"${tokens.join(" ")}"`],
     env: childEnv,
+    windowsVerbatimArguments: true,
   }
 }
 
@@ -109,10 +127,7 @@ export async function execPaseo(args: readonly string[], timeout: number) {
   return execFileAsync(invocation.executable, invocation.args, {
     timeout,
     env: invocation.env,
-    // Node re-escapes the quotes above as \" unless it hands the command
-    // string to cmd.exe verbatim, and cmd.exe has no \" escape: it looked for
-    // a command literally named \"paseo\".
-    windowsVerbatimArguments: process.platform === "win32",
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   })
 }
 


### PR DESCRIPTION
## What

On Windows every command the plugin shells out to fails — `plugin ls`, `plugin install`, `plugin update`:

```
Couldn't check installed plugins: Command failed: C:\WINDOWS\system32\cmd.exe /d /s /c "paseo" "plugin" "ls" "--json"
'"paseo"' is not recognized as an internal or external command
```

The Directory surface can't list or install anything, even with `paseo` correctly on `PATH` (verified by running the same command by hand).

## Why

`buildPaseoInvocation` passed win32 the command string `"paseo" "plugin" "ls" "--json"`. Two things then fight each other:

1. `cmd /d /s /c` strips **one** outer pair of quotes before resolving the command name. With no outer pair, the quoted name survives as `paseo" "plugin`, and cmd.exe goes looking for a command by that name.
2. `execFile` re-escapes embedded quotes as `\"` unless the command string is passed verbatim. cmd.exe has no `\"` escape, so it looked for a command literally named `\"paseo\"` — the exact string in the error above.

This is Windows-only; the POSIX branch spawns `paseo` directly and is unaffected.

## Fix

- The command string carries the outer pair that `/s` strips: `""paseo" "plugin" "ls" "--json""`.
- `execPaseo` passes `windowsVerbatimArguments`, so node hands that string to cmd.exe untouched.

Either half alone still fails, so both are needed:

| command string | spawn | result |
| --- | --- | --- |
| `"paseo" "plugin" ...` | plain | `'"paseo"' is not recognized` |
| `"paseo" "plugin" ...` | verbatim | `'paseo" "plugin" ...' is not recognized` |
| `""paseo" "plugin" ...""` | plain | `'\"\"paseo\" ...\"\"' is not recognized` |
| `""paseo" "plugin" ...""` | verbatim | runs, CLI argv `["plugin","ls","--json"]` |

Quoting every token is kept rather than dropped, so arguments containing spaces survive the shim chain.

## Tests

The existing test compared the argv — precisely the half that already looked right. This adds one that spawns a stub `paseo` shim through a temp directory on `PATH` and asserts the argv a real CLI process receives (`["plugin","ls","--json"]`), so the argv and the spawn options are exercised together instead of assumed. It runs on both platforms (cmd.exe shim on Windows, a shell shim elsewhere).

On the pre-fix invocation it fails with the user-facing error from the report; on the fixed one it passes.

- `npm run typecheck` — clean
- `npm test` — 82 passed across 4 files, on a Windows 11 host, so the `win32`
  branches of the shim test ran against a real `cmd.exe`
- `biome check --error-on-warnings plugin` — clean on the LF content CI checks out

## CI

Green on every runner of the matrix added in `53b0635` (run `34576056756`):
`Plugin (ubuntu-latest)`, `Plugin (windows-latest)`, `Plugin (macos-latest)`,
plus `App` and `All checks passed`. The Windows job reports 82 passed across 4
files, so the `win32` branch of the shim test now executes against a real
`cmd.exe` in CI rather than only on a maintainer's host.

## Reproduction

Windows 11 26200, Paseo 0.8.0, `paseo` on the daemon's `PATH`, plugin loadable → open the Paseo Cafe sidebar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows command-line handling so Paseo CLI commands run correctly through npm-style `.cmd` shims.
  - Preserved command arguments accurately when invoking the CLI on Windows.
  - Rejected unsupported backslashes in Windows command arguments.

- **Tests**
  - Added coverage for executing Paseo through temporary shims on Windows and Unix-like systems.
  - Updated Windows invocation expectations to reflect corrected quoting.
  - Expanded automated checks across Linux, Windows, and macOS environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

