### PR TITLE
Add usage-sidebar

### DIFF
--- a/registry/usage-sidebar.json
+++ b/registry/usage-sidebar.json
@@ -1,0 +1,10 @@
+{
+  "repo": "RUIIIOVO/paseo-usage-sidebar",
+  "categories": ["monitoring"],
+  "caveats": [
+    "Requires Paseo 0.8.0 or later",
+    "The always-visible sidebar meter is desktop and web only; the panel works everywhere",
+    "Only providers that report usage to the daemon get a row"
+  ],
+  "submittedBy": "RUIIIOVO"
+}


### PR DESCRIPTION
Adds [`usage-sidebar`](https://github.com/RUIIIOVO/paseo-usage-sidebar) — provider plan usage in the Paseo sidebar.

Paseo already knows how much of your plan is left, but keeps it behind **Settings → Usage** and a hover tooltip on the composer's context meter. This plugin surfaces the same data as an openable panel *and* as an always-visible meter under its own sidebar entry.

- Reads Paseo's own `provider.usage.list` through `paseo.providers.listUsage()` — no new credentials, no vendor CLI, no second polling path, so the numbers always match the settings screen.
- Pin, hide, and reorder the windows that show in the sidebar meter.
- Localized into Paseo's nine languages; window names follow the app's language setting rather than the daemon's English-only labels.
- `requirements.paseo: ">=0.8.0"`, MIT, no runtime dependencies beyond what Paseo supplies.

Verified with a clean `paseo plugin add RUIIIOVO/paseo-usage-sidebar` against Paseo 0.8.0: installs, loads, and renders from the Git checkout.

`bun run registry:validate` passes locally (52 entries OK).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a registry entry for the Paseo usage sidebar extension.
  - Includes monitoring categorization, compatibility requirements, platform limitations, provider availability details, and submission information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->