### PR TITLE
feat(registry): add paseo-beads

### DIFF
--- a/registry/paseo-beads.json
+++ b/registry/paseo-beads.json
@@ -1,0 +1,11 @@
+{
+  "repo": "omercnet/paseo-plugins",
+  "path": "paseo-beads",
+  "categories": ["monitoring", "productivity"],
+  "caveats": [
+    "Requires Paseo 0.8.x",
+    "Requires bd 1.0 or newer on the Paseo daemon host and an initialized Beads workspace",
+    "Read-only: does not create or update Beads issues"
+  ],
+  "submittedBy": "omercnet"
+}


### PR DESCRIPTION
## Summary

- add the merged `paseo-beads` plugin from `omercnet/paseo-plugins:paseo-beads`
- categorize it under monitoring and productivity
- surface its Paseo 0.8, Beads CLI, initialized-workspace, and read-only requirements

The catalog scan resolves version `0.0.1`, MIT license, README, tests/typecheck health, and both synthetic screenshots from the plugin repository.

## Verification

- authenticated `bun run registry:scan` - paseo-beads record generated cleanly
- `bun run check:app`
- `bun run typecheck`
- `bun run test` - 184 passing
- `bun run build:generated`

## Known base-repository blocker

`bun run registry:validate` currently fails on the pre-existing `registry/vscode-git.json` entry because `RedwindA/paseo-vscode-git` returns GitHub 404. The new `paseo-beads.json` entry itself validates and scans cleanly. Per request, this PR does not delete or modify that unrelated listing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Paseo and Beads integration to the registry.
  * Documented its monitoring and productivity categorization, version and workspace requirements, and read-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->