### PR TITLE
feat(registry): add gas-city

### DIFF
--- a/registry/gas-city.json
+++ b/registry/gas-city.json
@@ -1,0 +1,11 @@
+{
+  "repo": "omercnet/paseo-plugins",
+  "path": "paseo-gas-city",
+  "categories": ["orchestration", "monitoring", "productivity"],
+  "caveats": [
+    "Requires Paseo 0.8.x",
+    "Requires a reachable Gas City v1.4.1 supervisor on the Paseo daemon host",
+    "Native Open in Paseo session bridging is unavailable until Gas City exposes correlated prompt and reply identifiers"
+  ],
+  "submittedBy": "omercnet"
+}


### PR DESCRIPTION
## Summary

- add the merged `gas-city` plugin from `omercnet/paseo-plugins:paseo-gas-city`
- categorize it under orchestration, monitoring, and productivity
- surface its Paseo 0.8, Gas City v1.4.1, and native-session-bridge compatibility requirements

The authenticated catalog scan resolves version `0.0.1`, MIT license, README, tests/typecheck health, Reading Room screenshots, install notes, and package metadata from the plugin repository.

## Verification

- `bun run registry:validate` — 56 entries valid
- authenticated `bun run registry:scan` — 56 clean, 0 warnings
- `bun run check:app`
- `bun run typecheck`
- `bun run test` — 188 passing
- `bun run build:generated`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Paseo Gas City plugin to the registry.
  - Listed the plugin’s orchestration, monitoring, and productivity capabilities.
  - Documented compatibility requirements and current session-bridging limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->