### PR TITLE
feat(catalog): sort plugins by when they were added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # Full history: scripts/scan.ts derives each plugin's addedAt from
+          # the commit that first added its registry entry, and a shallow
+          # clone has no such history to read.
+          fetch-depth: 0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # Full history: scripts/scan.ts derives each plugin's addedAt from
+          # the commit that first added its registry entry, and a shallow
+          # clone has no such history to read.
+          fetch-depth: 0
 
       # Where this deployment actually lives. The canonical site has a custom
       # domain and is served from the root; a fork's project site is served

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -286,7 +286,6 @@ interface SortOption {
 const SORT_OPTIONS: readonly SortOption[] = [
   { value: "updates-first", label: "Updates first" },
   { value: "popular", label: "Popular" },
-  { value: "recent", label: "Recent repo activity" },
   { value: "recently-added", label: DIRECTORY_ADDED_AT_LABEL },
   { value: "a-z", label: "A–Z" },
 ]
@@ -303,15 +302,6 @@ function compareText(a: string | undefined, b: string | undefined): number {
   if (left < right) return -1
   if (left > right) return 1
   return 0
-}
-
-function timeValue(value: string | undefined): number {
-  const parsed = value ? Date.parse(value) : 0
-  return Number.isFinite(parsed) ? parsed : 0
-}
-
-function compareDateDesc(a: string | undefined, b: string | undefined): number {
-  return timeValue(b) - timeValue(a)
 }
 
 function compareStarsDesc(a: DirectoryEntry, b: DirectoryEntry): number {
@@ -341,7 +331,6 @@ function compareEntries(
       Number(entryHasUpdate(b, installationByEntryId)) -
         Number(entryHasUpdate(a, installationByEntryId)) ||
       compareStarsDesc(a, b) ||
-      compareDateDesc(a.repoMeta?.pushedAt, b.repoMeta?.pushedAt) ||
       compareText(a.name, b.name) ||
       compareText(a.repo, b.repo) ||
       compareText(a.id, b.id)
@@ -350,17 +339,6 @@ function compareEntries(
 
   if (sortMode === "popular") {
     return (
-      compareStarsDesc(a, b) ||
-      compareDateDesc(a.repoMeta?.pushedAt, b.repoMeta?.pushedAt) ||
-      compareText(a.name, b.name) ||
-      compareText(a.repo, b.repo) ||
-      compareText(a.id, b.id)
-    )
-  }
-
-  if (sortMode === "recent") {
-    return (
-      compareDateDesc(a.repoMeta?.pushedAt, b.repoMeta?.pushedAt) ||
       compareStarsDesc(a, b) ||
       compareText(a.name, b.name) ||
       compareText(a.repo, b.repo) ||
@@ -904,16 +882,6 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         : [],
     [defaultBrowseState, filtered, installationByEntryId]
   )
-  const recentActivityHighlights = useMemo(
-    () =>
-      defaultBrowseState
-        ? sortEntries(filtered, "recent", installationByEntryId).slice(
-            0,
-            FEATURED_LIMIT
-          )
-        : [],
-    [defaultBrowseState, filtered, installationByEntryId]
-  )
   // Entries with no usable listing date are left out entirely: a catalog that
   // doesn't publish valid addedAt values shows no section rather than an
   // arbitrary five.
@@ -1271,7 +1239,6 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
             ) : null}
             {defaultBrowseState &&
             (popularHighlights.length > 0 ||
-              recentActivityHighlights.length > 0 ||
               recentlyAddedHighlights.length > 0) ? (
               <View style={styles.featuredBlock}>
                 {popularHighlights.length > 0 ? (
@@ -1291,35 +1258,6 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
                       {popularHighlights.map((item) => (
                         <PluginRow
                           key={`popular-${item.id}`}
-                          entry={item}
-                          theme={theme}
-                          installations={
-                            installationByEntryId.get(item.id) ?? []
-                          }
-                          compact={layout.compact}
-                          onPress={() => openPlugin(item)}
-                        />
-                      ))}
-                    </View>
-                  </View>
-                ) : null}
-                {recentActivityHighlights.length > 0 ? (
-                  <View style={styles.featuredSection}>
-                    <View style={styles.sectionHeading}>
-                      <Text
-                        accessibilityRole="header"
-                        style={styles.featuredHeader}
-                      >
-                        Recent repo activity
-                      </Text>
-                      <Text style={styles.featuredDescription}>
-                        Plugins whose source repositories were pushed recently.
-                      </Text>
-                    </View>
-                    <View style={styles.featuredItems}>
-                      {recentActivityHighlights.map((item) => (
-                        <PluginRow
-                          key={`recent-${item.id}`}
                           entry={item}
                           theme={theme}
                           installations={

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -25,7 +25,6 @@ import {
   directoryInstallRpc,
   directoryListRpc,
   directorySettings,
-  directorySortDateField,
   directoryUpdateRpc,
   directoryUpdateStatusRpc,
   findInstallations,
@@ -1319,7 +1318,6 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
                       {recentHighlights.map((item) => (
                         <PluginRow
                           key={`recent-${item.id}`}
-                          dateField="updated"
                           entry={item}
                           theme={theme}
                           installations={
@@ -1349,7 +1347,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
                       {recentlyAddedHighlights.map((item) => (
                         <PluginRow
                           key={`recently-added-${item.id}`}
-                          dateField="added"
+                          showAddedDate
                           entry={item}
                           theme={theme}
                           installations={
@@ -1382,7 +1380,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
             theme={theme}
             installations={installationByEntryId.get(item.id) ?? []}
             compact={layout.compact}
-            dateField={directorySortDateField(sortMode)}
+            showAddedDate={sortMode === "recently-added"}
             onPress={() => openPlugin(item)}
           />
         )}

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -29,6 +29,7 @@ import {
   directoryUpdateStatusRpc,
   findInstallations,
   getInstallRef,
+  isDefaultDirectoryBrowseView,
   normalizeDirectoryCategories,
 } from "../shared/directory"
 import { filterAccessibilityLabel } from "./accessibility"
@@ -392,20 +393,6 @@ function sortEntries(
 ): DirectoryEntry[] {
   return [...entries].sort((a, b) =>
     compareEntries(a, b, sortMode, installationByEntryId)
-  )
-}
-
-function isDefaultBrowseState(
-  search: string,
-  categoryFilter: ReadonlySet<string>,
-  platformFilter: ReadonlySet<string>,
-  statusFilter: InstallationStatusFilter
-): boolean {
-  return (
-    search.trim() === "" &&
-    categoryFilter.size === 0 &&
-    platformFilter.size === 0 &&
-    statusFilter === "all"
   )
 }
 
@@ -898,12 +885,8 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       }),
     [nonStatusFiltered, effectiveStatusFilter, installationByEntryId]
   )
-  const defaultBrowseState = isDefaultBrowseState(
-    search,
-    categoryFilter,
-    platformFilter,
-    statusFilter
-  )
+  // browseSettings already carries exactly the state this depends on.
+  const defaultBrowseState = isDefaultDirectoryBrowseView(browseSettings)
 
   const sorted = useMemo(
     () => sortEntries(filtered, sortMode, installationByEntryId),

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -30,6 +30,7 @@ import {
   findInstallations,
   getInstallRef,
   isDefaultDirectoryBrowseView,
+  isDirectoryAddedAtKnown,
   normalizeDirectoryCategories,
 } from "../shared/directory"
 import { filterAccessibilityLabel } from "./accessibility"
@@ -285,7 +286,7 @@ interface SortOption {
 const SORT_OPTIONS: readonly SortOption[] = [
   { value: "updates-first", label: "Updates first" },
   { value: "popular", label: "Popular" },
-  { value: "recent", label: "Recently updated" },
+  { value: "recent", label: "Recent repo activity" },
   { value: "recently-added", label: DIRECTORY_ADDED_AT_LABEL },
   { value: "a-z", label: "A–Z" },
 ]
@@ -903,7 +904,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         : [],
     [defaultBrowseState, filtered, installationByEntryId]
   )
-  const recentHighlights = useMemo(
+  const recentActivityHighlights = useMemo(
     () =>
       defaultBrowseState
         ? sortEntries(filtered, "recent", installationByEntryId).slice(
@@ -913,13 +914,14 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         : [],
     [defaultBrowseState, filtered, installationByEntryId]
   )
-  // Entries with no known listing date are left out entirely: a catalog that
-  // doesn't publish addedAt shows no section rather than an arbitrary five.
+  // Entries with no usable listing date are left out entirely: a catalog that
+  // doesn't publish valid addedAt values shows no section rather than an
+  // arbitrary five.
   const recentlyAddedHighlights = useMemo(
     () =>
       defaultBrowseState
         ? sortEntries(
-            filtered.filter((entry) => entry.addedAt),
+            filtered.filter(isDirectoryAddedAtKnown),
             "recently-added",
             installationByEntryId
           ).slice(0, FEATURED_LIMIT)
@@ -1269,7 +1271,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
             ) : null}
             {defaultBrowseState &&
             (popularHighlights.length > 0 ||
-              recentHighlights.length > 0 ||
+              recentActivityHighlights.length > 0 ||
               recentlyAddedHighlights.length > 0) ? (
               <View style={styles.featuredBlock}>
                 {popularHighlights.length > 0 ? (
@@ -1301,21 +1303,21 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
                     </View>
                   </View>
                 ) : null}
-                {recentHighlights.length > 0 ? (
+                {recentActivityHighlights.length > 0 ? (
                   <View style={styles.featuredSection}>
                     <View style={styles.sectionHeading}>
                       <Text
                         accessibilityRole="header"
                         style={styles.featuredHeader}
                       >
-                        Recently updated
+                        Recent repo activity
                       </Text>
                       <Text style={styles.featuredDescription}>
-                        Plugins with recent repository activity.
+                        Plugins whose source repositories were pushed recently.
                       </Text>
                     </View>
                     <View style={styles.featuredItems}>
-                      {recentHighlights.map((item) => (
+                      {recentActivityHighlights.map((item) => (
                         <PluginRow
                           key={`recent-${item.id}`}
                           entry={item}

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -25,6 +25,7 @@ import {
   directoryInstallRpc,
   directoryListRpc,
   directorySettings,
+  directorySortDateField,
   directoryUpdateRpc,
   directoryUpdateStatusRpc,
   findInstallations,
@@ -1318,6 +1319,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
                       {recentHighlights.map((item) => (
                         <PluginRow
                           key={`recent-${item.id}`}
+                          dateField="updated"
                           entry={item}
                           theme={theme}
                           installations={
@@ -1347,6 +1349,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
                       {recentlyAddedHighlights.map((item) => (
                         <PluginRow
                           key={`recently-added-${item.id}`}
+                          dateField="added"
                           entry={item}
                           theme={theme}
                           installations={
@@ -1379,6 +1382,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
             theme={theme}
             installations={installationByEntryId.get(item.id) ?? []}
             compact={layout.compact}
+            dateField={directorySortDateField(sortMode)}
             onPress={() => openPlugin(item)}
           />
         )}

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -16,6 +16,8 @@ import type {
   InstalledPlugin,
 } from "../shared/directory"
 import {
+  compareDirectoryAddedAt,
+  DIRECTORY_ADDED_AT_LABEL,
   DIRECTORY_CATEGORIES,
   DIRECTORY_CATEGORY_LABELS,
   DIRECTORY_PLATFORM_LABELS,
@@ -283,6 +285,7 @@ const SORT_OPTIONS: readonly SortOption[] = [
   { value: "updates-first", label: "Updates first" },
   { value: "popular", label: "Popular" },
   { value: "recent", label: "Recently updated" },
+  { value: "recently-added", label: DIRECTORY_ADDED_AT_LABEL },
   { value: "a-z", label: "A–Z" },
 ]
 
@@ -356,6 +359,18 @@ function compareEntries(
   if (sortMode === "recent") {
     return (
       compareDateDesc(a.repoMeta?.pushedAt, b.repoMeta?.pushedAt) ||
+      compareStarsDesc(a, b) ||
+      compareText(a.name, b.name) ||
+      compareText(a.repo, b.repo) ||
+      compareText(a.id, b.id)
+    )
+  }
+
+  // Newest catalog listings first, using the same rule as the website's
+  // "Recently added" sort (see compareCatalogAddedAt in ../shared/catalog).
+  if (sortMode === "recently-added") {
+    return (
+      compareDirectoryAddedAt(a, b) ||
       compareStarsDesc(a, b) ||
       compareText(a.name, b.name) ||
       compareText(a.repo, b.repo) ||
@@ -915,6 +930,19 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         : [],
     [defaultBrowseState, filtered, installationByEntryId]
   )
+  // Entries with no known listing date are left out entirely: a catalog that
+  // doesn't publish addedAt shows no section rather than an arbitrary five.
+  const recentlyAddedHighlights = useMemo(
+    () =>
+      defaultBrowseState
+        ? sortEntries(
+            filtered.filter((entry) => entry.addedAt),
+            "recently-added",
+            installationByEntryId
+          ).slice(0, FEATURED_LIMIT)
+        : [],
+    [defaultBrowseState, filtered, installationByEntryId]
+  )
 
   function openPlugin(entry: DirectoryEntry) {
     setLastOpenedPluginId(entry.id)
@@ -1257,7 +1285,9 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
               </Text>
             ) : null}
             {defaultBrowseState &&
-            (popularHighlights.length > 0 || recentHighlights.length > 0) ? (
+            (popularHighlights.length > 0 ||
+              recentHighlights.length > 0 ||
+              recentlyAddedHighlights.length > 0) ? (
               <View style={styles.featuredBlock}>
                 {popularHighlights.length > 0 ? (
                   <View style={styles.featuredSection}>
@@ -1305,6 +1335,35 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
                       {recentHighlights.map((item) => (
                         <PluginRow
                           key={`recent-${item.id}`}
+                          entry={item}
+                          theme={theme}
+                          installations={
+                            installationByEntryId.get(item.id) ?? []
+                          }
+                          compact={layout.compact}
+                          onPress={() => openPlugin(item)}
+                        />
+                      ))}
+                    </View>
+                  </View>
+                ) : null}
+                {recentlyAddedHighlights.length > 0 ? (
+                  <View style={styles.featuredSection}>
+                    <View style={styles.sectionHeading}>
+                      <Text
+                        accessibilityRole="header"
+                        style={styles.featuredHeader}
+                      >
+                        {DIRECTORY_ADDED_AT_LABEL}
+                      </Text>
+                      <Text style={styles.featuredDescription}>
+                        The newest listings in the directory.
+                      </Text>
+                    </View>
+                    <View style={styles.featuredItems}>
+                      {recentlyAddedHighlights.map((item) => (
+                        <PluginRow
+                          key={`recently-added-${item.id}`}
                           entry={item}
                           theme={theme}
                           installations={

--- a/plugin/client/PluginDetailPage.tsx
+++ b/plugin/client/PluginDetailPage.tsx
@@ -16,6 +16,7 @@ import type {
 import {
   DIRECTORY_CATEGORY_LABELS,
   DIRECTORY_PLATFORM_LABELS,
+  formatDirectoryDate,
   formatDirectoryVersion,
   getInstallCommand,
   getInstallRef,
@@ -49,9 +50,9 @@ interface PluginDetailPageProps {
   onBack: () => void
 }
 
-/** "2026-09-08T01:09:51Z" -> "2026-09-08". No Intl formatting — good enough for a byline. */
+/** "2026-09-08T01:09:51Z" -> "08 Sep 2026", the same rendering the website uses. */
 function formatDate(iso: string | undefined): string | undefined {
-  return iso ? iso.slice(0, 10) : undefined
+  return iso ? formatDirectoryDate(iso) : undefined
 }
 
 function installationStateLabel(installation: InstalledPlugin): string {

--- a/plugin/client/PluginDetailPage.tsx
+++ b/plugin/client/PluginDetailPage.tsx
@@ -618,7 +618,7 @@ export function PluginDetailPage({
           ) : null}
           {formatDate(entry.repoMeta?.pushedAt) ? (
             <Text style={styles.metaText}>
-              Last updated {formatDate(entry.repoMeta?.pushedAt)}
+              Last repository push {formatDate(entry.repoMeta?.pushedAt)}
             </Text>
           ) : null}
           <Pressable

--- a/plugin/client/PluginDetailPage.tsx
+++ b/plugin/client/PluginDetailPage.tsx
@@ -519,7 +519,6 @@ export function PluginDetailPage({
       : `${passedHealthChecks} passed · ${failedHealthChecks} not passed${
           unknownHealthChecks > 0 ? ` · ${unknownHealthChecks} unknown` : ""
         }`
-  const sourceUpdatedDate = formatDate(entry.repoMeta?.pushedAt)
   const catalogScannedDate = formatDate(entry.scannedAt)
   const securityScannedDate = formatDate(securityAttestation?.scannedAt)
   const securityReportUrl = securityAttestation?.reportUrl
@@ -615,11 +614,6 @@ export function PluginDetailPage({
           ) : null}
           {entry.author ? (
             <Text style={styles.metaText}>By {entry.author}</Text>
-          ) : null}
-          {formatDate(entry.repoMeta?.pushedAt) ? (
-            <Text style={styles.metaText}>
-              Last repository push {formatDate(entry.repoMeta?.pushedAt)}
-            </Text>
           ) : null}
           <Pressable
             accessibilityRole="link"
@@ -1140,17 +1134,12 @@ export function PluginDetailPage({
             </View>
           </View>
           <View style={styles.section}>
-            <Text style={styles.label}>Freshness and status</Text>
+            <Text style={styles.label}>Catalog status</Text>
             {securityAttestation?.commit && installRef ? (
               <Text style={styles.modalText}>
                 Before installation, Paseo Cafe verifies that {installRef} still
                 points to scanned commit{" "}
                 {securityAttestation.commit.slice(0, 12)}.
-              </Text>
-            ) : null}
-            {sourceUpdatedDate ? (
-              <Text style={styles.modalText}>
-                Repository updated: {sourceUpdatedDate}
               </Text>
             ) : null}
             {catalogScannedDate ? (

--- a/plugin/client/PluginRow.tsx
+++ b/plugin/client/PluginRow.tsx
@@ -19,10 +19,8 @@ interface PluginRowProps {
   compact: boolean
   installations: readonly InstalledPlugin[]
   /**
-   * Whether to show when the catalog listed this plugin. The row always shows
-   * when the source repository was last updated, so that date needs no flag;
-   * this one appears when the list is ordered by it, so the order can be read
-   * off the rows.
+   * Whether to show when the catalog listed this plugin. Repository push time
+   * is always visible; this date appears when the list is ordered by it.
    */
   showAddedDate?: boolean
   onPress: () => void
@@ -207,7 +205,7 @@ export function PluginRow({
         : undefined
 
   const starCount = entry.repoMeta?.stars
-  const updatedBadge = getDirectoryDateBadge(entry, "updated")
+  const pushedBadge = getDirectoryDateBadge(entry, "pushed")
   const addedBadge = showAddedDate
     ? getDirectoryDateBadge(entry, "added")
     : undefined
@@ -266,9 +264,9 @@ export function PluginRow({
             <Text style={styles.metaBadgeText("muted")}>{addedBadge}</Text>
           </View>
         ) : null}
-        {updatedBadge ? (
+        {pushedBadge ? (
           <View style={styles.metaBadge}>
-            <Text style={styles.metaBadgeText("muted")}>{updatedBadge}</Text>
+            <Text style={styles.metaBadgeText("muted")}>{pushedBadge}</Text>
           </View>
         ) : null}
         <View style={styles.metaBadge}>

--- a/plugin/client/PluginRow.tsx
+++ b/plugin/client/PluginRow.tsx
@@ -255,11 +255,6 @@ export function PluginRow({
             </Text>
           </View>
         ) : null}
-        {entry.version ? (
-          <View style={styles.metaBadge}>
-            <Text style={styles.metaBadgeText("accent")}>v{entry.version}</Text>
-          </View>
-        ) : null}
         {addedBadge ? (
           <View style={styles.metaBadge}>
             <Text style={styles.metaBadgeText("muted")}>{addedBadge}</Text>

--- a/plugin/client/PluginRow.tsx
+++ b/plugin/client/PluginRow.tsx
@@ -2,11 +2,16 @@ import type { PluginTheme } from "@getpaseo/plugin"
 import { Icon } from "@getpaseo/plugin/client/react-native"
 import { useMemo } from "react"
 import { Image, Pressable, Text, View } from "react-native"
-import type { DirectoryEntry, InstalledPlugin } from "../shared/directory"
+import type {
+  DirectoryDateField,
+  DirectoryEntry,
+  InstalledPlugin,
+} from "../shared/directory"
 import {
   DIRECTORY_CATEGORY_LABELS,
   DIRECTORY_PLATFORM_LABELS,
   formatDirectoryVersion,
+  getDirectoryDateBadge,
   HEALTH_KEYS,
   normalizeDirectoryCategory,
 } from "../shared/directory"
@@ -17,6 +22,12 @@ interface PluginRowProps {
   theme: PluginTheme
   compact: boolean
   installations: readonly InstalledPlugin[]
+  /**
+   * The date this list is currently ordered by, if any. The row always shows
+   * when its source repository was last updated; ordering by listing date
+   * adds that date too, so the order can be read off the rows.
+   */
+  dateField?: DirectoryDateField
   onPress: () => void
 }
 
@@ -73,6 +84,7 @@ export function PluginRow({
   theme,
   compact,
   installations,
+  dateField,
   onPress,
 }: PluginRowProps) {
   const styles = useMemo(
@@ -198,7 +210,9 @@ export function PluginRow({
         : undefined
 
   const starCount = entry.repoMeta?.stars
-  const updatedAt = entry.repoMeta?.pushedAt?.slice(0, 10)
+  const updatedBadge = getDirectoryDateBadge(entry, "updated")
+  const addedBadge =
+    dateField === "added" ? getDirectoryDateBadge(entry, "added") : undefined
   const healthBadge = getHealthBadge(entry)
   const versionLabel = formatDirectoryVersion(entry.version)
   const compatibilityLabel = entry.paseoVersionRequirement
@@ -249,11 +263,14 @@ export function PluginRow({
             </Text>
           </View>
         ) : null}
-        {updatedAt ? (
+        {addedBadge ? (
           <View style={styles.metaBadge}>
-            <Text style={styles.metaBadgeText("muted")}>
-              Updated {updatedAt}
-            </Text>
+            <Text style={styles.metaBadgeText("muted")}>{addedBadge}</Text>
+          </View>
+        ) : null}
+        {updatedBadge ? (
+          <View style={styles.metaBadge}>
+            <Text style={styles.metaBadgeText("muted")}>{updatedBadge}</Text>
           </View>
         ) : null}
         <View style={styles.metaBadge}>

--- a/plugin/client/PluginRow.tsx
+++ b/plugin/client/PluginRow.tsx
@@ -7,7 +7,7 @@ import {
   DIRECTORY_CATEGORY_LABELS,
   DIRECTORY_PLATFORM_LABELS,
   formatDirectoryVersion,
-  getDirectoryDateBadge,
+  getDirectoryAddedDateBadge,
   HEALTH_KEYS,
   normalizeDirectoryCategory,
 } from "../shared/directory"
@@ -18,10 +18,7 @@ interface PluginRowProps {
   theme: PluginTheme
   compact: boolean
   installations: readonly InstalledPlugin[]
-  /**
-   * Whether to show when the catalog listed this plugin. Repository push time
-   * is always visible; this date appears when the list is ordered by it.
-   */
+  /** Show when the catalog listed this plugin while ordered by that date. */
   showAddedDate?: boolean
   onPress: () => void
 }
@@ -205,9 +202,8 @@ export function PluginRow({
         : undefined
 
   const starCount = entry.repoMeta?.stars
-  const pushedBadge = getDirectoryDateBadge(entry, "pushed")
   const addedBadge = showAddedDate
-    ? getDirectoryDateBadge(entry, "added")
+    ? getDirectoryAddedDateBadge(entry)
     : undefined
   const healthBadge = getHealthBadge(entry)
   const versionLabel = formatDirectoryVersion(entry.version)
@@ -259,14 +255,14 @@ export function PluginRow({
             </Text>
           </View>
         ) : null}
+        {entry.version ? (
+          <View style={styles.metaBadge}>
+            <Text style={styles.metaBadgeText("accent")}>v{entry.version}</Text>
+          </View>
+        ) : null}
         {addedBadge ? (
           <View style={styles.metaBadge}>
             <Text style={styles.metaBadgeText("muted")}>{addedBadge}</Text>
-          </View>
-        ) : null}
-        {pushedBadge ? (
-          <View style={styles.metaBadge}>
-            <Text style={styles.metaBadgeText("muted")}>{pushedBadge}</Text>
           </View>
         ) : null}
         <View style={styles.metaBadge}>

--- a/plugin/client/PluginRow.tsx
+++ b/plugin/client/PluginRow.tsx
@@ -2,11 +2,7 @@ import type { PluginTheme } from "@getpaseo/plugin"
 import { Icon } from "@getpaseo/plugin/client/react-native"
 import { useMemo } from "react"
 import { Image, Pressable, Text, View } from "react-native"
-import type {
-  DirectoryDateField,
-  DirectoryEntry,
-  InstalledPlugin,
-} from "../shared/directory"
+import type { DirectoryEntry, InstalledPlugin } from "../shared/directory"
 import {
   DIRECTORY_CATEGORY_LABELS,
   DIRECTORY_PLATFORM_LABELS,
@@ -23,11 +19,12 @@ interface PluginRowProps {
   compact: boolean
   installations: readonly InstalledPlugin[]
   /**
-   * The date this list is currently ordered by, if any. The row always shows
-   * when its source repository was last updated; ordering by listing date
-   * adds that date too, so the order can be read off the rows.
+   * Whether to show when the catalog listed this plugin. The row always shows
+   * when the source repository was last updated, so that date needs no flag;
+   * this one appears when the list is ordered by it, so the order can be read
+   * off the rows.
    */
-  dateField?: DirectoryDateField
+  showAddedDate?: boolean
   onPress: () => void
 }
 
@@ -84,7 +81,7 @@ export function PluginRow({
   theme,
   compact,
   installations,
-  dateField,
+  showAddedDate,
   onPress,
 }: PluginRowProps) {
   const styles = useMemo(
@@ -211,8 +208,9 @@ export function PluginRow({
 
   const starCount = entry.repoMeta?.stars
   const updatedBadge = getDirectoryDateBadge(entry, "updated")
-  const addedBadge =
-    dateField === "added" ? getDirectoryDateBadge(entry, "added") : undefined
+  const addedBadge = showAddedDate
+    ? getDirectoryDateBadge(entry, "added")
+    : undefined
   const healthBadge = getHealthBadge(entry)
   const versionLabel = formatDirectoryVersion(entry.version)
   const compatibilityLabel = entry.paseoVersionRequirement

--- a/plugin/shared/catalog.ts
+++ b/plugin/shared/catalog.ts
@@ -271,12 +271,52 @@ export function formatCatalogDate(iso: string): string | undefined {
   return `${day} ${CATALOG_MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()}`
 }
 
-/** "Added 08 Sep 2026" / "Updated 08 Sep 2026", or undefined when unknown. */
-export function getCatalogDateBadge(
+/**
+ * The reader's own rendering of the same instant: Intl picks the field order
+ * and month name from their locale, and the day is the one their clock shows,
+ * so "Sep 11, 2026" for en-US and "11 Sept 2026" for en-GB.
+ *
+ * Falls back to formatCatalogDate for anything Intl can't do. That matters in
+ * two real places: a React Native runtime built without full ICU, and the
+ * website's server render, which happens before the reader's locale and time
+ * zone are knowable — see ReaderDate in src/components/reader-date.tsx, which
+ * renders the fallback and swaps to this once mounted.
+ */
+export function formatCatalogDateForReader(
+  iso: string,
+  locale?: string
+): string | undefined {
+  const parsed = Date.parse(iso)
+  if (!Number.isFinite(parsed)) return undefined
+  if (typeof Intl === "undefined" || !Intl.DateTimeFormat) {
+    return formatCatalogDate(iso)
+  }
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(new Date(parsed))
+  } catch {
+    return formatCatalogDate(iso)
+  }
+}
+
+/** The raw timestamp a listing's date badge is built from, if it has one. */
+export function getCatalogDateValue(
   entry: { addedAt?: string; repoMeta?: { pushedAt?: string } },
   field: CatalogDateField
 ): string | undefined {
-  const iso = field === "added" ? entry.addedAt : entry.repoMeta?.pushedAt
-  const formatted = iso ? formatCatalogDate(iso) : undefined
+  return field === "added" ? entry.addedAt : entry.repoMeta?.pushedAt
+}
+
+/** "Added Sep 11, 2026" / "Updated Sep 11, 2026", or undefined when unknown. */
+export function getCatalogDateBadge(
+  entry: { addedAt?: string; repoMeta?: { pushedAt?: string } },
+  field: CatalogDateField,
+  locale?: string
+): string | undefined {
+  const iso = getCatalogDateValue(entry, field)
+  const formatted = iso ? formatCatalogDateForReader(iso, locale) : undefined
   return formatted && `${CATALOG_DATE_LABELS[field]} ${formatted}`
 }

--- a/plugin/shared/catalog.ts
+++ b/plugin/shared/catalog.ts
@@ -177,16 +177,23 @@ export function getCatalogInstallCommand(entry: {
   return args ? ["paseo", "plugin", "add", ...args].join(" ") : undefined
 }
 
+export type CatalogHealthCheck =
+  | "manifestValid"
+  | "hasReadme"
+  | "hasLicense"
+  | "hasTests"
+  | "hasTypecheckScript"
+  | "updatedRecently"
+
+// User-facing health excludes repository activity: plugin updates are defined
+// by package.json semver, not by unrelated pushes to a source repository.
 export const CATALOG_HEALTH_KEYS = [
   "manifestValid",
   "hasReadme",
   "hasLicense",
   "hasTests",
   "hasTypecheckScript",
-  "updatedRecently",
-] as const
-
-export type CatalogHealthCheck = (typeof CATALOG_HEALTH_KEYS)[number]
+] as const satisfies readonly CatalogHealthCheck[]
 
 export const CATALOG_HEALTH_LABELS: Record<CatalogHealthCheck, string> = {
   manifestValid: "Manifest ID matches registry",
@@ -232,18 +239,6 @@ export function compareCatalogAddedAt(
   b: CatalogAddedAt
 ): number {
   return getCatalogAddedAtTime(b) - getCatalogAddedAtTime(a)
-}
-
-/**
- * Which date a listing is being ordered by. A repository push is deliberately
- * not called an update: package.json semver is the plugin update identity,
- * while pushedAt only measures activity anywhere in its source repository.
- */
-export type CatalogDateField = "added" | "pushed"
-
-export const CATALOG_DATE_LABELS: Record<CatalogDateField, string> = {
-  added: "Added",
-  pushed: "Repo push",
 }
 
 const CATALOG_MONTHS = [
@@ -307,21 +302,13 @@ export function formatCatalogDateForReader(
   }
 }
 
-/** The raw timestamp a listing's date badge is built from, if it has one. */
-export function getCatalogDateValue(
-  entry: { addedAt?: string; repoMeta?: { pushedAt?: string } },
-  field: CatalogDateField
-): string | undefined {
-  return field === "added" ? entry.addedAt : entry.repoMeta?.pushedAt
-}
-
-/** "Added Sep 11, 2026" / "Repo push Sep 11, 2026", or undefined. */
-export function getCatalogDateBadge(
-  entry: { addedAt?: string; repoMeta?: { pushedAt?: string } },
-  field: CatalogDateField,
+/** "Added Sep 11, 2026", or undefined when the listing date is unknown. */
+export function getCatalogAddedDateBadge(
+  entry: CatalogAddedAt,
   locale?: string
 ): string | undefined {
-  const iso = getCatalogDateValue(entry, field)
-  const formatted = iso ? formatCatalogDateForReader(iso, locale) : undefined
-  return formatted && `${CATALOG_DATE_LABELS[field]} ${formatted}`
+  const formatted = entry.addedAt
+    ? formatCatalogDateForReader(entry.addedAt, locale)
+    : undefined
+  return formatted && `Added ${formatted}`
 }

--- a/plugin/shared/catalog.ts
+++ b/plugin/shared/catalog.ts
@@ -228,3 +228,55 @@ export function compareCatalogAddedAt(
 ): number {
   return getCatalogAddedAtTime(b) - getCatalogAddedAtTime(a)
 }
+
+/**
+ * Which date a listing is being ordered by. Both surfaces put the matching
+ * date on the row while that sort is active, so the ordering is legible
+ * instead of implied — "Recently added" without a date is just a list.
+ */
+export type CatalogDateField = "added" | "updated"
+
+export const CATALOG_DATE_LABELS: Record<CatalogDateField, string> = {
+  added: "Added",
+  updated: "Updated",
+}
+
+const CATALOG_MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+]
+
+/**
+ * "2026-09-08T01:09:51Z" -> "08 Sep 2026". Built by hand from UTC fields
+ * rather than through Intl: the website renders this on the server and again
+ * in the browser, and a locale or ICU difference between the two is a React
+ * hydration mismatch. Undefined for anything unparseable, so a bad date shows
+ * nothing rather than "NaN".
+ */
+export function formatCatalogDate(iso: string): string | undefined {
+  const parsed = Date.parse(iso)
+  if (!Number.isFinite(parsed)) return undefined
+  const date = new Date(parsed)
+  const day = String(date.getUTCDate()).padStart(2, "0")
+  return `${day} ${CATALOG_MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()}`
+}
+
+/** "Added 08 Sep 2026" / "Updated 08 Sep 2026", or undefined when unknown. */
+export function getCatalogDateBadge(
+  entry: { addedAt?: string; repoMeta?: { pushedAt?: string } },
+  field: CatalogDateField
+): string | undefined {
+  const iso = field === "added" ? entry.addedAt : entry.repoMeta?.pushedAt
+  const formatted = iso ? formatCatalogDate(iso) : undefined
+  return formatted && `${CATALOG_DATE_LABELS[field]} ${formatted}`
+}

--- a/plugin/shared/catalog.ts
+++ b/plugin/shared/catalog.ts
@@ -196,3 +196,35 @@ export const CATALOG_HEALTH_LABELS: Record<CatalogHealthCheck, string> = {
   hasTypecheckScript: "Has a typecheck script",
   updatedRecently: "Updated in the last 6 months",
 }
+
+/**
+ * When a plugin's registry entry first landed in this repository's git
+ * history (ISO 8601) — i.e. when the catalog accepted it. The scanner
+ * derives it (see scripts/scan.ts on the website); it is never hand-authored,
+ * so it can't be backdated or nudged forward by a submitter, and it means
+ * the same thing on both surfaces. It is absent when the history isn't
+ * available (a shallow clone, or an entry that isn't committed yet).
+ */
+export const CATALOG_ADDED_AT_LABEL = "Recently added"
+
+export interface CatalogAddedAt {
+  addedAt?: string
+}
+
+/** Epoch milliseconds for a catalog timestamp; 0 when missing or unparseable. */
+export function getCatalogAddedAtTime(entry: CatalogAddedAt): number {
+  const parsed = entry.addedAt ? Date.parse(entry.addedAt) : Number.NaN
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/**
+ * Most recently listed first. Entries with no known date sort last rather
+ * than first, so a missing date never fakes its way to the top of the list.
+ * Callers break ties with their own stable ordering.
+ */
+export function compareCatalogAddedAt(
+  a: CatalogAddedAt,
+  b: CatalogAddedAt
+): number {
+  return getCatalogAddedAtTime(b) - getCatalogAddedAtTime(a)
+}

--- a/plugin/shared/catalog.ts
+++ b/plugin/shared/catalog.ts
@@ -194,7 +194,7 @@ export const CATALOG_HEALTH_LABELS: Record<CatalogHealthCheck, string> = {
   hasLicense: "Has a license",
   hasTests: "Has tests",
   hasTypecheckScript: "Has a typecheck script",
-  updatedRecently: "Updated in the last 6 months",
+  updatedRecently: "Repository active in the last 6 months",
 }
 
 /**
@@ -217,6 +217,11 @@ export function getCatalogAddedAtTime(entry: CatalogAddedAt): number {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
+/** Whether an entry has a usable catalog-listing timestamp. */
+export function isCatalogAddedAtKnown(entry: CatalogAddedAt): boolean {
+  return getCatalogAddedAtTime(entry) > 0
+}
+
 /**
  * Most recently listed first. Entries with no known date sort last rather
  * than first, so a missing date never fakes its way to the top of the list.
@@ -230,15 +235,15 @@ export function compareCatalogAddedAt(
 }
 
 /**
- * Which date a listing is being ordered by. Both surfaces put the matching
- * date on the row while that sort is active, so the ordering is legible
- * instead of implied — "Recently added" without a date is just a list.
+ * Which date a listing is being ordered by. A repository push is deliberately
+ * not called an update: package.json semver is the plugin update identity,
+ * while pushedAt only measures activity anywhere in its source repository.
  */
-export type CatalogDateField = "added" | "updated"
+export type CatalogDateField = "added" | "pushed"
 
 export const CATALOG_DATE_LABELS: Record<CatalogDateField, string> = {
   added: "Added",
-  updated: "Updated",
+  pushed: "Repo push",
 }
 
 const CATALOG_MONTHS = [
@@ -310,7 +315,7 @@ export function getCatalogDateValue(
   return field === "added" ? entry.addedAt : entry.repoMeta?.pushedAt
 }
 
-/** "Added Sep 11, 2026" / "Updated Sep 11, 2026", or undefined when unknown. */
+/** "Added Sep 11, 2026" / "Repo push Sep 11, 2026", or undefined. */
 export function getCatalogDateBadge(
   entry: { addedAt?: string; repoMeta?: { pushedAt?: string } },
   field: CatalogDateField,

--- a/plugin/shared/catalog.ts
+++ b/plugin/shared/catalog.ts
@@ -221,7 +221,7 @@ export interface CatalogAddedAt {
 /** Epoch milliseconds for a catalog timestamp; 0 when missing or unparseable. */
 export function getCatalogAddedAtTime(entry: CatalogAddedAt): number {
   const parsed = entry.addedAt ? Date.parse(entry.addedAt) : Number.NaN
-  return Number.isFinite(parsed) ? parsed : 0
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
 }
 
 /** Whether an entry has a usable catalog-listing timestamp. */

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -20,6 +20,7 @@ import {
   getRepositoryUrl,
   getRepositoryUrlAtRef,
   getSiteUrl,
+  isDefaultDirectoryBrowseView,
   isOfficialPlugin,
   isTrustedCatalogUrl,
   isValidInstallPath,
@@ -207,6 +208,37 @@ describe("catalog URL transport policy", () => {
     )
     expect(
       directoryUpdateStatusRpc.input.safeParse({ baseUrl: url }).success
+    ).toBe(false)
+  })
+})
+
+describe("default browse view", () => {
+  it("treats the untouched surface as the default view", () => {
+    expect(
+      isDefaultDirectoryBrowseView(DEFAULT_DIRECTORY_BROWSE_SETTINGS)
+    ).toBe(true)
+  })
+
+  it("stops being the default view once a different sort is chosen", () => {
+    expect(
+      isDefaultDirectoryBrowseView({
+        ...DEFAULT_DIRECTORY_BROWSE_SETTINGS,
+        sort: "recently-added",
+      })
+    ).toBe(false)
+  })
+
+  it.each([
+    { query: "git" },
+    { categories: ["git" as const] },
+    { platforms: ["macos"] },
+    { status: "installed" as const },
+  ])("stops being the default view when filtered by %o", (overrides) => {
+    expect(
+      isDefaultDirectoryBrowseView({
+        ...DEFAULT_DIRECTORY_BROWSE_SETTINGS,
+        ...overrides,
+      })
     ).toBe(false)
   })
 })

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -295,6 +295,12 @@ describe("directory listing dates", () => {
 
   it("does not treat a truthy invalid date as a known listing date", () => {
     expect(isDirectoryAddedAtKnown({ addedAt: "whenever" })).toBe(false)
+    expect(isDirectoryAddedAtKnown({ addedAt: "1969-12-31T23:59:59Z" })).toBe(
+      false
+    )
+    expect(
+      compareDirectoryAddedAt({ addedAt: "1969-12-31T23:59:59Z" }, {})
+    ).toBe(0)
     expect(isDirectoryAddedAtKnown({ addedAt: "2026-01-01T00:00:00Z" })).toBe(
       true
     )

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -22,6 +22,7 @@ import {
   getRepositoryUrlAtRef,
   getSiteUrl,
   isDefaultDirectoryBrowseView,
+  isDirectoryAddedAtKnown,
   isOfficialPlugin,
   isTrustedCatalogUrl,
   isValidInstallPath,
@@ -228,8 +229,8 @@ describe("listing date badges", () => {
     expect(getDirectoryDateBadge(entry, "added", "en-GB")).toBe(
       `Added ${localDay} Sept 2026`
     )
-    expect(getDirectoryDateBadge(entry, "updated", "en-US")).toMatch(
-      /^Updated Jan \d{1,2}, 2026$/
+    expect(getDirectoryDateBadge(entry, "pushed", "en-US")).toMatch(
+      /^Repo push Jan \d{1,2}, 2026$/
     )
   })
 
@@ -244,7 +245,7 @@ describe("listing date badges", () => {
     expect(
       getDirectoryDateBadge({ addedAt: "whenever" }, "added")
     ).toBeUndefined()
-    expect(getDirectoryDateBadge({ repoMeta: {} }, "updated")).toBeUndefined()
+    expect(getDirectoryDateBadge({ repoMeta: {} }, "pushed")).toBeUndefined()
   })
 })
 
@@ -299,6 +300,13 @@ describe("directory listing dates", () => {
     expect(
       compareDirectoryAddedAt(entry, { addedAt: "2026-01-01T00:00:00Z" })
     ).toBeGreaterThan(0)
+  })
+
+  it("does not treat a truthy invalid date as a known listing date", () => {
+    expect(isDirectoryAddedAtKnown({ addedAt: "whenever" })).toBe(false)
+    expect(isDirectoryAddedAtKnown({ addedAt: "2026-01-01T00:00:00Z" })).toBe(
+      true
+    )
   })
 
   it("orders newest listings first and unknown dates last", () => {

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -14,7 +14,9 @@ import {
   directoryReadmeAttachments,
   directorySecurityAttachments,
   directorySettings,
+  directorySortDateField,
   directoryUpdateStatusRpc,
+  getDirectoryDateBadge,
   getInstallCommand,
   getInstallRef,
   getRepositoryUrl,
@@ -209,6 +211,34 @@ describe("catalog URL transport policy", () => {
     expect(
       directoryUpdateStatusRpc.input.safeParse({ baseUrl: url }).success
     ).toBe(false)
+  })
+})
+
+describe("listing date badges", () => {
+  it("labels each date with the same wording and format as the website", () => {
+    const entry = {
+      addedAt: "2026-09-08T01:09:51Z",
+      repoMeta: { pushedAt: "2026-01-05T23:00:00Z" },
+    }
+
+    expect(getDirectoryDateBadge(entry, "added")).toBe("Added 08 Sep 2026")
+    expect(getDirectoryDateBadge(entry, "updated")).toBe("Updated 05 Jan 2026")
+  })
+
+  it("shows nothing for a missing or unusable date", () => {
+    expect(getDirectoryDateBadge({}, "added")).toBeUndefined()
+    expect(
+      getDirectoryDateBadge({ addedAt: "whenever" }, "added")
+    ).toBeUndefined()
+    expect(getDirectoryDateBadge({ repoMeta: {} }, "updated")).toBeUndefined()
+  })
+
+  it("labels the date each sort orders by, and no other", () => {
+    expect(directorySortDateField("recently-added")).toBe("added")
+    expect(directorySortDateField("recent")).toBe("updated")
+    expect(directorySortDateField("popular")).toBeUndefined()
+    expect(directorySortDateField("updates-first")).toBeUndefined()
+    expect(directorySortDateField("a-z")).toBeUndefined()
   })
 })
 

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest"
 import {
+  compareDirectoryAddedAt,
   DEFAULT_DIRECTORY_BROWSE_SETTINGS,
+  DIRECTORY_ADDED_AT_LABEL,
   DIRECTORY_CATEGORY_LABELS,
   type DirectoryCategory,
   directoryAttachments,
@@ -206,6 +208,48 @@ describe("catalog URL transport policy", () => {
     expect(
       directoryUpdateStatusRpc.input.safeParse({ baseUrl: url }).success
     ).toBe(false)
+  })
+})
+
+describe("directory listing dates", () => {
+  it("keeps the catalog's listing date on parsed entries", () => {
+    expect(
+      directoryEntrySchema.parse({
+        ...validEntry,
+        addedAt: "2026-03-04T05:06:07Z",
+      }).addedAt
+    ).toBe("2026-03-04T05:06:07Z")
+  })
+
+  it("keeps an entry whose listing date is unusable instead of dropping it", () => {
+    const entry = directoryEntrySchema.parse({
+      ...validEntry,
+      addedAt: "whenever",
+    })
+
+    expect(entry.id).toBe("plugin")
+    expect(
+      compareDirectoryAddedAt(entry, { addedAt: "2026-01-01T00:00:00Z" })
+    ).toBeGreaterThan(0)
+  })
+
+  it("orders newest listings first and unknown dates last", () => {
+    const entries = [
+      { id: "unknown" },
+      { id: "older", addedAt: "2026-01-01T00:00:00Z" },
+      { id: "newer", addedAt: "2026-07-01T00:00:00Z" },
+    ]
+
+    expect(
+      [...entries].sort(compareDirectoryAddedAt).map((entry) => entry.id)
+    ).toEqual(["newer", "older", "unknown"])
+  })
+
+  it("persists the shared sort mode under the same label as the website", () => {
+    expect(
+      directoryBrowseSettingsSchema.parse({ sort: "recently-added" }).sort
+    ).toBe("recently-added")
+    expect(DIRECTORY_ADDED_AT_LABEL).toBe("Recently added")
   })
 })
 

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -15,7 +15,7 @@ import {
   directorySecurityAttachments,
   directorySettings,
   directoryUpdateStatusRpc,
-  getDirectoryDateBadge,
+  getDirectoryAddedDateBadge,
   getInstallCommand,
   getInstallRef,
   getRepositoryUrl,
@@ -216,36 +216,27 @@ describe("catalog URL transport policy", () => {
 
 describe("listing date badges", () => {
   // Mid-month and mid-day, so no time zone can shift it into another month.
-  const entry = {
-    addedAt: "2026-09-15T12:00:00Z",
-    repoMeta: { pushedAt: "2026-01-15T12:00:00Z" },
-  }
+  const entry = { addedAt: "2026-09-15T12:00:00Z" }
   const localDay = new Date(entry.addedAt).getDate()
 
-  it("labels each date and renders it the reader's way", () => {
-    expect(getDirectoryDateBadge(entry, "added", "en-US")).toBe(
+  it("labels listing dates and renders them the reader's way", () => {
+    expect(getDirectoryAddedDateBadge(entry, "en-US")).toBe(
       `Added Sep ${localDay}, 2026`
     )
-    expect(getDirectoryDateBadge(entry, "added", "en-GB")).toBe(
+    expect(getDirectoryAddedDateBadge(entry, "en-GB")).toBe(
       `Added ${localDay} Sept 2026`
-    )
-    expect(getDirectoryDateBadge(entry, "pushed", "en-US")).toMatch(
-      /^Repo push Jan \d{1,2}, 2026$/
     )
   })
 
   it("falls back to a fixed UTC rendering when the locale is unusable", () => {
-    expect(getDirectoryDateBadge(entry, "added", "not a locale")).toBe(
+    expect(getDirectoryAddedDateBadge(entry, "not a locale")).toBe(
       "Added 15 Sep 2026"
     )
   })
 
   it("shows nothing for a missing or unusable date", () => {
-    expect(getDirectoryDateBadge({}, "added")).toBeUndefined()
-    expect(
-      getDirectoryDateBadge({ addedAt: "whenever" }, "added")
-    ).toBeUndefined()
-    expect(getDirectoryDateBadge({ repoMeta: {} }, "pushed")).toBeUndefined()
+    expect(getDirectoryAddedDateBadge({})).toBeUndefined()
+    expect(getDirectoryAddedDateBadge({ addedAt: "whenever" })).toBeUndefined()
   })
 })
 
@@ -326,6 +317,9 @@ describe("directory listing dates", () => {
       directoryBrowseSettingsSchema.parse({ sort: "recently-added" }).sort
     ).toBe("recently-added")
     expect(DIRECTORY_ADDED_AT_LABEL).toBe("Recently added")
+    expect(
+      directoryBrowseSettingsSchema.safeParse({ sort: "recent" }).success
+    ).toBe(false)
   })
 })
 
@@ -399,6 +393,23 @@ describe("directory taxonomy and browse settings", () => {
       directoryUrl,
       browse: DEFAULT_DIRECTORY_BROWSE_SETTINGS,
     })
+  })
+
+  it("migrates the removed repository-activity sort to version updates", () => {
+    const migrated = migrateDirectorySettings(
+      {
+        directoryUrl: "https://catalog.internal/api/plugins",
+        browse: {
+          ...DEFAULT_DIRECTORY_BROWSE_SETTINGS,
+          sort: "recent",
+        },
+      },
+      2
+    )
+
+    expect(directorySettings.schema.parse(migrated).browse.sort).toBe(
+      "updates-first"
+    )
   })
 })
 

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -215,14 +215,29 @@ describe("catalog URL transport policy", () => {
 })
 
 describe("listing date badges", () => {
-  it("labels each date with the same wording and format as the website", () => {
-    const entry = {
-      addedAt: "2026-09-08T01:09:51Z",
-      repoMeta: { pushedAt: "2026-01-05T23:00:00Z" },
-    }
+  // Mid-month and mid-day, so no time zone can shift it into another month.
+  const entry = {
+    addedAt: "2026-09-15T12:00:00Z",
+    repoMeta: { pushedAt: "2026-01-15T12:00:00Z" },
+  }
+  const localDay = new Date(entry.addedAt).getDate()
 
-    expect(getDirectoryDateBadge(entry, "added")).toBe("Added 08 Sep 2026")
-    expect(getDirectoryDateBadge(entry, "updated")).toBe("Updated 05 Jan 2026")
+  it("labels each date and renders it the reader's way", () => {
+    expect(getDirectoryDateBadge(entry, "added", "en-US")).toBe(
+      `Added Sep ${localDay}, 2026`
+    )
+    expect(getDirectoryDateBadge(entry, "added", "en-GB")).toBe(
+      `Added ${localDay} Sept 2026`
+    )
+    expect(getDirectoryDateBadge(entry, "updated", "en-US")).toMatch(
+      /^Updated Jan \d{1,2}, 2026$/
+    )
+  })
+
+  it("falls back to a fixed UTC rendering when the locale is unusable", () => {
+    expect(getDirectoryDateBadge(entry, "added", "not a locale")).toBe(
+      "Added 15 Sep 2026"
+    )
   })
 
   it("shows nothing for a missing or unusable date", () => {

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -14,7 +14,6 @@ import {
   directoryReadmeAttachments,
   directorySecurityAttachments,
   directorySettings,
-  directorySortDateField,
   directoryUpdateStatusRpc,
   getDirectoryDateBadge,
   getInstallCommand,
@@ -246,14 +245,6 @@ describe("listing date badges", () => {
       getDirectoryDateBadge({ addedAt: "whenever" }, "added")
     ).toBeUndefined()
     expect(getDirectoryDateBadge({ repoMeta: {} }, "updated")).toBeUndefined()
-  })
-
-  it("labels the date each sort orders by, and no other", () => {
-    expect(directorySortDateField("recently-added")).toBe("added")
-    expect(directorySortDateField("recent")).toBe("updated")
-    expect(directorySortDateField("popular")).toBeUndefined()
-    expect(directorySortDateField("updates-first")).toBeUndefined()
-    expect(directorySortDateField("a-z")).toBeUndefined()
   })
 })
 

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -150,6 +150,29 @@ function containsSameValues(
   return true
 }
 
+/**
+ * Whether the surface is showing its default, unfiltered view — the only
+ * state where the curated highlight sections belong. The sort is part of
+ * that: the highlights are the one part of the surface that does *not*
+ * reorder, so leaving them in place after someone picks a different sort
+ * reads as the sort having done nothing. Mirrors the website's `showFeatured`
+ * rule in src/routes/index.tsx; keep the two in step.
+ */
+export function isDefaultDirectoryBrowseView(
+  browse: Pick<
+    DirectoryBrowseSettings,
+    "query" | "categories" | "platforms" | "status" | "sort"
+  >
+): boolean {
+  return (
+    browse.query.trim() === "" &&
+    browse.categories.length === 0 &&
+    browse.platforms.length === 0 &&
+    browse.status === DEFAULT_DIRECTORY_BROWSE_SETTINGS.status &&
+    browse.sort === DEFAULT_DIRECTORY_BROWSE_SETTINGS.sort
+  )
+}
+
 /** Compares persisted browse state using set semantics for multi-select filters. */
 export function directoryBrowseSettingsEqual(
   left: DirectoryBrowseSettings,

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -17,7 +17,7 @@ import {
   type CatalogDateField,
   type CatalogHealthCheck,
   compareCatalogAddedAt,
-  formatCatalogDate,
+  formatCatalogDateForReader,
   formatCatalogVersion,
   getCatalogDateBadge,
   getCatalogInstallCommand,
@@ -119,7 +119,7 @@ export const compareDirectoryAddedAt = compareCatalogAddedAt
 
 export type DirectoryDateField = CatalogDateField
 export const getDirectoryDateBadge = getCatalogDateBadge
-export const formatDirectoryDate = formatCatalogDate
+export const formatDirectoryDate = formatCatalogDateForReader
 
 /** The date a row should show while this sort is active, or none. */
 export function directorySortDateField(

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -14,7 +14,6 @@ import {
   CATALOG_PLATFORM_LABELS,
   CATALOG_VERSION_MAX_LENGTH,
   type CatalogCategory,
-  type CatalogDateField,
   type CatalogHealthCheck,
   compareCatalogAddedAt,
   formatCatalogDateForReader,
@@ -117,18 +116,8 @@ export const DIRECTORY_SORT_MODES = [
 export const DIRECTORY_ADDED_AT_LABEL = CATALOG_ADDED_AT_LABEL
 export const compareDirectoryAddedAt = compareCatalogAddedAt
 
-export type DirectoryDateField = CatalogDateField
 export const getDirectoryDateBadge = getCatalogDateBadge
 export const formatDirectoryDate = formatCatalogDateForReader
-
-/** The date a row should show while this sort is active, or none. */
-export function directorySortDateField(
-  sort: DirectoryBrowseSettings["sort"]
-): DirectoryDateField | undefined {
-  if (sort === "recently-added") return "added"
-  if (sort === "recent") return "updated"
-  return undefined
-}
 
 export const DIRECTORY_STATUS_FILTERS = [
   "all",

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -23,6 +23,7 @@ import {
   getCatalogInstallRef,
   getCatalogRepositoryOwner,
   getCatalogRepositoryUrl,
+  isCatalogAddedAtKnown,
   isOfficialCatalogPlugin,
   isValidCatalogCommit,
   isValidCatalogPath,
@@ -115,6 +116,7 @@ export const DIRECTORY_SORT_MODES = [
 /** Shared with the website's "Recently added" sort — see ./catalog.ts. */
 export const DIRECTORY_ADDED_AT_LABEL = CATALOG_ADDED_AT_LABEL
 export const compareDirectoryAddedAt = compareCatalogAddedAt
+export const isDirectoryAddedAtKnown = isCatalogAddedAtKnown
 
 export const getDirectoryDateBadge = getCatalogDateBadge
 export const formatDirectoryDate = formatCatalogDateForReader

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -14,9 +14,12 @@ import {
   CATALOG_PLATFORM_LABELS,
   CATALOG_VERSION_MAX_LENGTH,
   type CatalogCategory,
+  type CatalogDateField,
   type CatalogHealthCheck,
   compareCatalogAddedAt,
+  formatCatalogDate,
   formatCatalogVersion,
+  getCatalogDateBadge,
   getCatalogInstallCommand,
   getCatalogInstallRef,
   getCatalogRepositoryOwner,
@@ -113,6 +116,19 @@ export const DIRECTORY_SORT_MODES = [
 /** Shared with the website's "Recently added" sort — see ./catalog.ts. */
 export const DIRECTORY_ADDED_AT_LABEL = CATALOG_ADDED_AT_LABEL
 export const compareDirectoryAddedAt = compareCatalogAddedAt
+
+export type DirectoryDateField = CatalogDateField
+export const getDirectoryDateBadge = getCatalogDateBadge
+export const formatDirectoryDate = formatCatalogDate
+
+/** The date a row should show while this sort is active, or none. */
+export function directorySortDateField(
+  sort: DirectoryBrowseSettings["sort"]
+): DirectoryDateField | undefined {
+  if (sort === "recently-added") return "added"
+  if (sort === "recent") return "updated"
+  return undefined
+}
 
 export const DIRECTORY_STATUS_FILTERS = [
   "all",

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -18,7 +18,7 @@ import {
   compareCatalogAddedAt,
   formatCatalogDateForReader,
   formatCatalogVersion,
-  getCatalogDateBadge,
+  getCatalogAddedDateBadge,
   getCatalogInstallCommand,
   getCatalogInstallRef,
   getCatalogRepositoryOwner,
@@ -108,7 +108,6 @@ export const normalizeDirectoryCategories = normalizeCatalogCategories
 export const DIRECTORY_SORT_MODES = [
   "updates-first",
   "popular",
-  "recent",
   "recently-added",
   "a-z",
 ] as const
@@ -118,7 +117,7 @@ export const DIRECTORY_ADDED_AT_LABEL = CATALOG_ADDED_AT_LABEL
 export const compareDirectoryAddedAt = compareCatalogAddedAt
 export const isDirectoryAddedAtKnown = isCatalogAddedAtKnown
 
-export const getDirectoryDateBadge = getCatalogDateBadge
+export const getDirectoryAddedDateBadge = getCatalogAddedDateBadge
 export const formatDirectoryDate = formatCatalogDateForReader
 
 export const DIRECTORY_STATUS_FILTERS = [
@@ -200,7 +199,7 @@ export function migrateDirectorySettings(
   fromVersion: number
 ): unknown {
   if (
-    fromVersion >= 2 ||
+    fromVersion >= 3 ||
     typeof values !== "object" ||
     values === null ||
     Array.isArray(values)
@@ -209,9 +208,18 @@ export function migrateDirectorySettings(
   }
 
   const previous = values as Record<string, unknown>
+  const browse =
+    previous.browse &&
+    typeof previous.browse === "object" &&
+    !Array.isArray(previous.browse)
+      ? (previous.browse as Record<string, unknown>)
+      : DEFAULT_DIRECTORY_BROWSE_SETTINGS
   return {
     ...previous,
-    browse: previous.browse ?? DEFAULT_DIRECTORY_BROWSE_SETTINGS,
+    browse: {
+      ...browse,
+      ...(browse.sort === "recent" ? { sort: "updates-first" } : {}),
+    },
   }
 }
 
@@ -223,7 +231,7 @@ export function migrateDirectorySettings(
 export const directorySettings = defineSettings({
   id: "directory-settings",
   scope: "host",
-  version: 2,
+  version: 3,
   schema: z.object({
     directoryUrl: catalogUrlSchema.default(DEFAULT_DIRECTORY_URL),
     browse: directoryBrowseSettingsSchema.default(

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -6,6 +6,7 @@ import {
 } from "@getpaseo/plugin"
 import { z } from "zod"
 import {
+  CATALOG_ADDED_AT_LABEL,
   CATALOG_CATEGORIES,
   CATALOG_CATEGORY_LABELS,
   CATALOG_HEALTH_KEYS,
@@ -14,6 +15,7 @@ import {
   CATALOG_VERSION_MAX_LENGTH,
   type CatalogCategory,
   type CatalogHealthCheck,
+  compareCatalogAddedAt,
   formatCatalogVersion,
   getCatalogInstallCommand,
   getCatalogInstallRef,
@@ -104,8 +106,13 @@ export const DIRECTORY_SORT_MODES = [
   "updates-first",
   "popular",
   "recent",
+  "recently-added",
   "a-z",
 ] as const
+
+/** Shared with the website's "Recently added" sort — see ./catalog.ts. */
+export const DIRECTORY_ADDED_AT_LABEL = CATALOG_ADDED_AT_LABEL
+export const compareDirectoryAddedAt = compareCatalogAddedAt
 
 export const DIRECTORY_STATUS_FILTERS = [
   "all",
@@ -403,6 +410,11 @@ export const directoryEntrySchema = z.object({
   installNotesHtml: z.string().max(100_000).optional(),
   limitationsNotesHtml: z.string().max(100_000).optional(),
   scanError: z.string().max(4_000).optional(),
+  // When the catalog listed this plugin (see PluginRecord.addedAt on the
+  // site). Kept as a plain bounded string like scannedAt below: a catalog
+  // that sends a malformed date should cost that plugin its place in the
+  // "Recently added" order, not drop the whole entry from the list.
+  addedAt: z.string().max(100).optional(),
   scannedAt: z.string().max(100).optional(),
   health: z.object(directoryHealthShape).optional(),
   // Mirrors src/lib/plugin-schema.ts's pluginSecuritySchema invariants — a

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -1,10 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { PluginSecurity } from "../src/lib/plugin-schema"
 import {
   loadPublishedSecurityCatalog,
+  readRegistryAddedAt,
   renderPluginsRedirect,
   renderRobotsTxt,
   scanOne,
@@ -324,6 +326,73 @@ describe("renderRobotsTxt", () => {
   })
 })
 
+function git(repository: string, args: string[], committedAt?: string): void {
+  execFileSync("git", args, {
+    cwd: repository,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+      ...(committedAt
+        ? { GIT_AUTHOR_DATE: committedAt, GIT_COMMITTER_DATE: committedAt }
+        : {}),
+    },
+  })
+}
+
+function commitRegistryEntry(
+  repository: string,
+  file: string,
+  contents: Record<string, unknown>,
+  committedAt: string
+): void {
+  writeFileSync(join(repository, "registry", file), JSON.stringify(contents))
+  git(repository, ["add", `registry/${file}`])
+  git(repository, ["commit", "-m", `update ${file}`], committedAt)
+}
+
+describe("readRegistryAddedAt", () => {
+  it("reports when each entry first landed, not when it was last touched", () => {
+    const repository = temporaryDirectory()
+    mkdirSync(join(repository, "registry"))
+    git(repository, ["init", "--initial-branch=main"])
+
+    commitRegistryEntry(
+      repository,
+      "first.json",
+      { repo: "acme/widgets" },
+      "2026-01-02T03:04:05+00:00"
+    )
+    commitRegistryEntry(
+      repository,
+      "second.json",
+      { repo: "acme/gadgets" },
+      "2026-06-07T08:09:10+00:00"
+    )
+    // A later edit to an existing entry must not re-date it.
+    commitRegistryEntry(
+      repository,
+      "first.json",
+      { repo: "acme/widgets", path: "plugin" },
+      "2026-08-09T10:11:12+00:00"
+    )
+
+    const addedAt = readRegistryAddedAt(join(repository, "registry"))
+
+    expect(addedAt.get("first.json")).toBe("2026-01-02T03:04:05Z")
+    expect(addedAt.get("second.json")).toBe("2026-06-07T08:09:10Z")
+  })
+
+  it("returns nothing rather than a wrong date when there is no history", () => {
+    const registryRoot = exampleRegistry()
+
+    expect(readRegistryAddedAt(registryRoot).size).toBe(0)
+  })
+})
+
 describe("scanOne", () => {
   it("keeps branch metadata without attaching security when commit resolution fails", async () => {
     const registryRoot = exampleRegistry()
@@ -400,6 +469,7 @@ describe("scanOne", () => {
 
     const record = await scanOne("example.json", {}, registryRoot)
 
+    expect(record.addedAt).toBeUndefined()
     expect(record.scanError).toBe(
       "scan failed while reading repository: acme/widgets/plugin"
     )
@@ -420,9 +490,11 @@ describe("scanOne", () => {
     const record = await scanOne(
       "example.json",
       { example: security },
-      registryRoot
+      registryRoot,
+      "2026-03-04T05:06:07+00:00"
     )
 
+    expect(record.addedAt).toBe("2026-03-04T05:06:07+00:00")
     expect(record.url).toBe("https://github.com/acme/widgets/tree/main/plugin")
     expect(record.security).toEqual(security)
     expect(record.images).toEqual([

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -384,6 +390,36 @@ describe("readRegistryAddedAt", () => {
 
     expect(addedAt.get("first.json")).toBe("2026-01-02T03:04:05Z")
     expect(addedAt.get("second.json")).toBe("2026-06-07T08:09:10Z")
+  })
+
+  it("refuses a shallow clone rather than dating everything to its tip", () => {
+    const repository = temporaryDirectory()
+    mkdirSync(join(repository, "registry"))
+    git(repository, ["init", "--initial-branch=main"])
+    commitRegistryEntry(
+      repository,
+      "first.json",
+      { repo: "acme/widgets" },
+      "2026-01-02T03:04:05+00:00"
+    )
+    commitRegistryEntry(
+      repository,
+      "second.json",
+      { repo: "acme/gadgets" },
+      "2026-06-07T08:09:10+00:00"
+    )
+
+    // A depth-1 clone grafts a root commit that appears to add every tracked
+    // file, so an unguarded `git log` would report both entries as added on
+    // the day of the clone.
+    const shallow = temporaryDirectory()
+    git(shallow, ["clone", "--depth", "1", `file://${repository}`, "checkout"])
+
+    // Guard against the clone silently failing and the assertion below
+    // passing for the wrong reason.
+    const registryDir = join(shallow, "checkout", "registry")
+    expect(existsSync(join(registryDir, "first.json"))).toBe(true)
+    expect(readRegistryAddedAt(registryDir).size).toBe(0)
   })
 
   it("returns nothing rather than a wrong date when there is no history", () => {

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -392,6 +392,54 @@ describe("readRegistryAddedAt", () => {
     expect(addedAt.get("second.json")).toBe("2026-06-07T08:09:10Z")
   })
 
+  it("uses the integration date for a preserved contributor commit", () => {
+    const repository = temporaryDirectory()
+    git(repository, ["init", "--initial-branch=main"])
+    writeFileSync(join(repository, "README.md"), "catalog")
+    git(repository, ["add", "README.md"])
+    git(
+      repository,
+      ["commit", "-m", "initialize catalog"],
+      "2026-01-01T00:00:00+00:00"
+    )
+
+    git(repository, ["checkout", "-b", "contributor"])
+    mkdirSync(join(repository, "registry"))
+    commitRegistryEntry(
+      repository,
+      "future-dated.json",
+      { repo: "acme/widgets" },
+      "2099-12-01T00:00:00+00:00"
+    )
+
+    git(repository, ["checkout", "main"])
+    git(
+      repository,
+      ["merge", "--no-ff", "contributor", "-m", "merge plugin"],
+      "2026-09-10T00:00:00+00:00"
+    )
+
+    expect(
+      readRegistryAddedAt(join(repository, "registry")).get("future-dated.json")
+    ).toBe("2026-09-10T00:00:00Z")
+  })
+
+  it("omits a future-dated entry on the integration branch", () => {
+    const repository = temporaryDirectory()
+    mkdirSync(join(repository, "registry"))
+    git(repository, ["init", "--initial-branch=main"])
+    commitRegistryEntry(
+      repository,
+      "future-dated.json",
+      { repo: "acme/widgets" },
+      "2099-12-01T00:00:00+00:00"
+    )
+
+    expect(
+      readRegistryAddedAt(join(repository, "registry")).has("future-dated.json")
+    ).toBe(false)
+  })
+
   it("refuses a shallow clone rather than dating everything to its tip", () => {
     const repository = temporaryDirectory()
     mkdirSync(join(repository, "registry"))

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -12,6 +12,7 @@
  * safest defaults, so the listing can surface it as "needs attention"
  * instead of the whole build breaking.
  */
+import { execFileSync } from "node:child_process"
 import {
   existsSync,
   mkdirSync,
@@ -19,7 +20,7 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs"
-import { join } from "node:path"
+import { basename, join } from "node:path"
 import { z } from "zod"
 import {
   extractReadmeImages,
@@ -78,6 +79,68 @@ const SECURITY_ARTIFACT_PATH = join(
   "plugin-security-results.json"
 )
 const REPOSITORY_COMMIT_SCHEMA = z.object({ sha: gitCommitSchema })
+
+const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T/
+
+/**
+ * When each registry entry first landed in git, keyed by its filename —
+ * the catalog's "added to the directory" date. Derived rather than
+ * hand-authored so every existing entry has a real date and no submitter can
+ * date their own listing to the top of "Recently added".
+ *
+ * One `git log` pass covers the whole registry. Commits arrive newest-first,
+ * so the last date written for a file is its *earliest* add, which is the
+ * one that survives a delete-and-re-add. A shallow clone (or a checkout with
+ * no git at all) yields an empty map instead of a wrong one — callers treat
+ * an unknown date as unknown, never as "just added".
+ */
+export function readRegistryAddedAt(
+  registryDir = REGISTRY_DIR
+): Map<string, string> {
+  const addedAt = new Map<string, string>()
+
+  let log: string
+  try {
+    log = execFileSync(
+      "git",
+      [
+        "log",
+        "--diff-filter=A",
+        // Committer date: when the entry landed on the branch, which is what
+        // "added to the catalog" means. Author dates survive a squash merge
+        // from whenever the contributor first wrote the file locally.
+        "--format=%cI",
+        "--name-only",
+        "--",
+        registryDir,
+      ],
+      {
+        // Anywhere inside the work tree resolves the same repository; using
+        // the registry directory itself keeps the function testable against
+        // a throwaway repo.
+        cwd: registryDir,
+        encoding: "utf8",
+        maxBuffer: 32 * 1_024 * 1_024,
+        stdio: ["ignore", "pipe", "ignore"],
+      }
+    )
+  } catch {
+    return addedAt
+  }
+
+  let commitDate: string | undefined
+  for (const line of log.split("\n")) {
+    const value = line.trim()
+    if (value === "") continue
+    if (ISO_TIMESTAMP_PATTERN.test(value)) {
+      commitDate = value
+    } else if (commitDate && value.endsWith(".json")) {
+      addedAt.set(basename(value), commitDate)
+    }
+  }
+
+  return addedAt
+}
 
 export function securityForRevision(
   security: PluginSecurity | undefined,
@@ -159,7 +222,8 @@ function isRecent(iso: string): boolean {
 export async function scanOne(
   entryFile: string,
   securityCatalog: Record<string, PluginSecurity>,
-  registryDir = REGISTRY_DIR
+  registryDir = REGISTRY_DIR,
+  addedAt?: string
 ): Promise<PluginRecord> {
   const id = registryIdSchema.parse(entryFile.slice(0, -".json".length))
   const raw = JSON.parse(readFileSync(join(registryDir, entryFile), "utf8"))
@@ -188,6 +252,7 @@ export async function scanOne(
     },
     images: [],
     videos: [],
+    addedAt,
     scannedAt,
   }
 
@@ -377,6 +442,7 @@ export async function scanOne(
         archived: repoMeta.archived,
         license: repoMeta.license?.spdx_id ?? null,
       },
+      addedAt,
       scannedAt,
     }
 
@@ -533,11 +599,22 @@ async function main() {
   mkdirSync(OG_DIR, { recursive: true })
 
   const securityCatalog = loadPublishedSecurityCatalog()
+  const addedAt = readRegistryAddedAt()
+  if (addedAt.size === 0 && files.length > 0) {
+    console.warn(
+      "  ! no registry history in git (shallow clone?) — every plugin will be listed without an added date"
+    )
+  }
 
   const records: PluginRecord[] = []
   for (const file of files) {
     console.log(`Scanning ${file}...`)
-    const record = await scanOne(file, securityCatalog)
+    const record = await scanOne(
+      file,
+      securityCatalog,
+      REGISTRY_DIR,
+      addedAt.get(file)
+    )
     if (record.scanError) console.warn(`  ! ${record.scanError}`)
     records.push(record)
     writeFileSync(

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -105,9 +105,10 @@ function isShallowRepository(directory: string): boolean {
  * hand-authored so every existing entry has a real date and no submitter can
  * date their own listing to the top of "Recently added".
  *
- * One `git log` pass covers the whole registry. Commits arrive newest-first,
- * so the last date written for a file is its *earliest* add, which is the
- * one that survives a delete-and-re-add.
+ * One first-parent `git log` pass covers the whole registry. Merge commits are
+ * diffed against their first parent, so a preserved contributor commit cannot
+ * supply its own listing date. Commits arrive newest-first, so the last date
+ * written for a file is its earliest add, which survives delete-and-re-add.
  *
  * A shallow clone is refused rather than read. Its grafted root commit
  * appears to add every tracked file at once, so `git log` reports the entire
@@ -128,10 +129,11 @@ export function readRegistryAddedAt(
       "git",
       [
         "log",
+        "--first-parent",
+        "-m",
         "--diff-filter=A",
-        // Committer date: when the entry landed on the branch, which is what
-        // "added to the catalog" means. Author dates survive a squash merge
-        // from whenever the contributor first wrote the file locally.
+        // Committer date on the integration history: when the entry landed on
+        // the catalog branch, not when a contributor authored or committed it.
         "--format=%cI",
         "--name-only",
         "--",
@@ -156,7 +158,9 @@ export function readRegistryAddedAt(
     const value = line.trim()
     if (value === "") continue
     if (ISO_TIMESTAMP_PATTERN.test(value)) {
-      commitDate = value
+      const parsed = Date.parse(value)
+      commitDate =
+        Number.isFinite(parsed) && parsed <= Date.now() ? value : undefined
     } else if (commitDate && value.endsWith(".json")) {
       addedAt.set(basename(value), commitDate)
     }

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -82,6 +82,23 @@ const REPOSITORY_COMMIT_SCHEMA = z.object({ sha: gitCommitSchema })
 
 const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T/
 
+/** True only for a clone whose history was truncated — see readRegistryAddedAt. */
+function isShallowRepository(directory: string): boolean {
+  try {
+    return (
+      execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+        cwd: directory,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim() === "true"
+    )
+  } catch {
+    // No git, or not a work tree. readRegistryAddedAt's own git call fails
+    // next and returns an empty map, which is the same answer.
+    return false
+  }
+}
+
 /**
  * When each registry entry first landed in git, keyed by its filename —
  * the catalog's "added to the directory" date. Derived rather than
@@ -90,14 +107,20 @@ const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T/
  *
  * One `git log` pass covers the whole registry. Commits arrive newest-first,
  * so the last date written for a file is its *earliest* add, which is the
- * one that survives a delete-and-re-add. A shallow clone (or a checkout with
- * no git at all) yields an empty map instead of a wrong one — callers treat
- * an unknown date as unknown, never as "just added".
+ * one that survives a delete-and-re-add.
+ *
+ * A shallow clone is refused rather than read. Its grafted root commit
+ * appears to add every tracked file at once, so `git log` reports the entire
+ * registry as added on the day the clone was made: every listing stamped
+ * with the build date, "Recently added" collapsed into one big tie, and
+ * nothing in the output to say so. An unknown date has to stay unknown, so
+ * this returns an empty map there — same as a checkout with no git at all.
  */
 export function readRegistryAddedAt(
   registryDir = REGISTRY_DIR
 ): Map<string, string> {
   const addedAt = new Map<string, string>()
+  if (isShallowRepository(registryDir)) return addedAt
 
   let log: string
   try {

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -567,8 +567,7 @@ export function writeSitemap(records: PluginRecord[]) {
         `  <url><loc>${SITE_URL}${path}</loc><changefreq>${changefreq}</changefreq></url>`
     ),
     ...records.map(
-      (r) =>
-        `  <url><loc>${SITE_URL}/plugins/${r.id}</loc><lastmod>${(r.repoMeta?.pushedAt ?? r.scannedAt).slice(0, 10)}</lastmod></url>`
+      (record) => `  <url><loc>${SITE_URL}/plugins/${record.id}</loc></url>`
     ),
     ...ownerLogins.map(
       (login) =>

--- a/src/components/catalog-results.tsx
+++ b/src/components/catalog-results.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router"
 import { PluginGrid } from "@/components/plugin-grid"
 import { Button } from "@/components/ui/button"
 import type { CatalogSearch } from "@/lib/catalog-search"
-import { sortLabels } from "@/lib/catalog-search"
+import { sortDateField, sortLabels } from "@/lib/catalog-search"
 import type { PluginRecord } from "@/lib/plugin-schema"
 
 interface CatalogResultsProps {
@@ -50,7 +50,7 @@ export function CatalogResults({
           </p>
         </div>
       </div>
-      <PluginGrid plugins={plugins} />
+      <PluginGrid plugins={plugins} dateField={sortDateField(search.sort)} />
       <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
         <p className="text-foreground/50 text-sm" aria-live="polite">
           Showing {pageStart + 1}–{pageEnd} of {totalCount} · Page {page} of{" "}

--- a/src/components/catalog-results.tsx
+++ b/src/components/catalog-results.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router"
 import { PluginGrid } from "@/components/plugin-grid"
 import { Button } from "@/components/ui/button"
 import type { CatalogSearch } from "@/lib/catalog-search"
-import { sortDateField, sortLabels } from "@/lib/catalog-search"
+import { sortLabels } from "@/lib/catalog-search"
 import type { PluginRecord } from "@/lib/plugin-schema"
 
 interface CatalogResultsProps {
@@ -50,7 +50,7 @@ export function CatalogResults({
           </p>
         </div>
       </div>
-      <PluginGrid plugins={plugins} dateField={sortDateField(search.sort)} />
+      <PluginGrid plugins={plugins} showAddedDate={search.sort === "added"} />
       <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
         <p className="text-foreground/50 text-sm" aria-live="polite">
           Showing {pageStart + 1}–{pageEnd} of {totalCount} · Page {page} of{" "}

--- a/src/components/featured-section.tsx
+++ b/src/components/featured-section.tsx
@@ -34,16 +34,7 @@ export function FeaturedSection({
             params={{ id: plugin.id }}
             className="flex min-w-0 items-center justify-between gap-3 border border-border bg-card px-3 py-2 transition-colors hover:bg-muted"
           >
-            <span className="flex min-w-0 items-center gap-2">
-              <span className="truncate font-medium text-sm">
-                {plugin.name}
-              </span>
-              {plugin.version ? (
-                <span className="shrink-0 text-foreground/50 text-xs">
-                  v{plugin.version}
-                </span>
-              ) : null}
-            </span>
+            <span className="truncate font-medium text-sm">{plugin.name}</span>
             <span className="shrink-0 text-foreground/50 text-xs">
               {plugin.repo}
             </span>

--- a/src/components/featured-section.tsx
+++ b/src/components/featured-section.tsx
@@ -34,7 +34,16 @@ export function FeaturedSection({
             params={{ id: plugin.id }}
             className="flex min-w-0 items-center justify-between gap-3 border border-border bg-card px-3 py-2 transition-colors hover:bg-muted"
           >
-            <span className="truncate font-medium text-sm">{plugin.name}</span>
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="truncate font-medium text-sm">
+                {plugin.name}
+              </span>
+              {plugin.version ? (
+                <span className="shrink-0 text-foreground/50 text-xs">
+                  v{plugin.version}
+                </span>
+              ) : null}
+            </span>
             <span className="shrink-0 text-foreground/50 text-xs">
               {plugin.repo}
             </span>

--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -90,9 +90,6 @@ export function PluginCard({
                 <ReaderDate iso={plugin.addedAt} />
               </Badge>
             ) : null}
-            {plugin.version ? (
-              <Badge variant="secondary">v{plugin.version}</Badge>
-            ) : null}
             <Badge variant={healthIsComplete ? "secondary" : "outline"}>
               {healthIsComplete ? "Healthy" : "Incomplete health checks"}
             </Badge>

--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -15,8 +15,25 @@ import {
 } from "@/components/ui/card"
 import type { PluginRecord } from "@/lib/plugin-schema"
 import { formatPluginVersion, PLATFORM_LABELS } from "@/lib/registry-schema"
+import {
+  type CatalogDateField,
+  getCatalogDateBadge,
+} from "../../plugin/shared/catalog"
 
-export function PluginCard({ plugin }: { plugin: PluginRecord }) {
+/**
+ * `dateField` is the date the catalog is currently ordered by, if any (see
+ * sortDateField in src/lib/catalog-search.ts). The card shows that one date
+ * so a "Recently added" or "Recently updated" ordering can be read off the
+ * results instead of taken on trust.
+ */
+export function PluginCard({
+  plugin,
+  dateField,
+}: {
+  plugin: PluginRecord
+  dateField?: CatalogDateField
+}) {
+  const dateBadge = dateField && getCatalogDateBadge(plugin, dateField)
   const healthIsComplete =
     plugin.health.manifestValid &&
     plugin.health.hasReadme &&
@@ -76,6 +93,7 @@ export function PluginCard({ plugin }: { plugin: PluginRecord }) {
                 {plugin.owner.login}
               </span>
             ) : null}
+            {dateBadge ? <Badge variant="secondary">{dateBadge}</Badge> : null}
             <Badge
               variant={plugin.health.updatedRecently ? "secondary" : "outline"}
             >

--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -16,25 +16,15 @@ import {
 } from "@/components/ui/card"
 import type { PluginRecord } from "@/lib/plugin-schema"
 import { formatPluginVersion, PLATFORM_LABELS } from "@/lib/registry-schema"
-import {
-  CATALOG_DATE_LABELS,
-  type CatalogDateField,
-  getCatalogDateValue,
-} from "../../plugin/shared/catalog"
 
-/**
- * `dateField` is the date the catalog is currently ordered by, if any (see
- * sortDateField in src/lib/catalog-search.ts). The card shows that date so a
- * "Recently added" or repository-activity ordering is explicit.
- */
+/** Shows the catalog listing date only when the results are ordered by it. */
 export function PluginCard({
   plugin,
-  dateField,
+  showAddedDate,
 }: {
   plugin: PluginRecord
-  dateField?: CatalogDateField
+  showAddedDate?: boolean
 }) {
-  const dateValue = dateField && getCatalogDateValue(plugin, dateField)
   const healthIsComplete =
     plugin.health.manifestValid &&
     plugin.health.hasReadme &&
@@ -83,7 +73,7 @@ export function PluginCard({
             {plugin.description || "No description available."}
           </CardDescription>
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="sr-only">Freshness and health</span>
+            <span className="sr-only">Version and health</span>
             {plugin.owner ? (
               <span className="flex items-center gap-1.5 text-foreground/50 text-xs">
                 <img
@@ -94,17 +84,15 @@ export function PluginCard({
                 {plugin.owner.login}
               </span>
             ) : null}
-            {dateField && dateValue ? (
+            {showAddedDate && plugin.addedAt ? (
               <Badge variant="secondary">
-                {CATALOG_DATE_LABELS[dateField]}&nbsp;
-                <ReaderDate iso={dateValue} />
+                Added&nbsp;
+                <ReaderDate iso={plugin.addedAt} />
               </Badge>
             ) : null}
-            <Badge
-              variant={plugin.health.updatedRecently ? "secondary" : "outline"}
-            >
-              {plugin.health.updatedRecently ? "Fresh" : "Stale"}
-            </Badge>
+            {plugin.version ? (
+              <Badge variant="secondary">v{plugin.version}</Badge>
+            ) : null}
             <Badge variant={healthIsComplete ? "secondary" : "outline"}>
               {healthIsComplete ? "Healthy" : "Incomplete health checks"}
             </Badge>

--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -5,6 +5,7 @@ import {
   IconVersions,
 } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
+import { ReaderDate } from "@/components/reader-date"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -16,8 +17,9 @@ import {
 import type { PluginRecord } from "@/lib/plugin-schema"
 import { formatPluginVersion, PLATFORM_LABELS } from "@/lib/registry-schema"
 import {
+  CATALOG_DATE_LABELS,
   type CatalogDateField,
-  getCatalogDateBadge,
+  getCatalogDateValue,
 } from "../../plugin/shared/catalog"
 
 /**
@@ -33,7 +35,7 @@ export function PluginCard({
   plugin: PluginRecord
   dateField?: CatalogDateField
 }) {
-  const dateBadge = dateField && getCatalogDateBadge(plugin, dateField)
+  const dateValue = dateField && getCatalogDateValue(plugin, dateField)
   const healthIsComplete =
     plugin.health.manifestValid &&
     plugin.health.hasReadme &&
@@ -93,7 +95,12 @@ export function PluginCard({
                 {plugin.owner.login}
               </span>
             ) : null}
-            {dateBadge ? <Badge variant="secondary">{dateBadge}</Badge> : null}
+            {dateField && dateValue ? (
+              <Badge variant="secondary">
+                {CATALOG_DATE_LABELS[dateField]}&nbsp;
+                <ReaderDate iso={dateValue} />
+              </Badge>
+            ) : null}
             <Badge
               variant={plugin.health.updatedRecently ? "secondary" : "outline"}
             >

--- a/src/components/plugin-card.tsx
+++ b/src/components/plugin-card.tsx
@@ -24,9 +24,8 @@ import {
 
 /**
  * `dateField` is the date the catalog is currently ordered by, if any (see
- * sortDateField in src/lib/catalog-search.ts). The card shows that one date
- * so a "Recently added" or "Recently updated" ordering can be read off the
- * results instead of taken on trust.
+ * sortDateField in src/lib/catalog-search.ts). The card shows that date so a
+ * "Recently added" or repository-activity ordering is explicit.
  */
 export function PluginCard({
   plugin,

--- a/src/components/plugin-grid.tsx
+++ b/src/components/plugin-grid.tsx
@@ -1,11 +1,18 @@
 import { PluginCard } from "@/components/plugin-card"
 import type { PluginRecord } from "@/lib/plugin-schema"
+import type { CatalogDateField } from "../../plugin/shared/catalog"
 
-export function PluginGrid({ plugins }: { plugins: PluginRecord[] }) {
+export function PluginGrid({
+  plugins,
+  dateField,
+}: {
+  plugins: PluginRecord[]
+  dateField?: CatalogDateField
+}) {
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
       {plugins.map((plugin) => (
-        <PluginCard key={plugin.id} plugin={plugin} />
+        <PluginCard key={plugin.id} plugin={plugin} dateField={dateField} />
       ))}
     </div>
   )

--- a/src/components/plugin-grid.tsx
+++ b/src/components/plugin-grid.tsx
@@ -1,18 +1,21 @@
 import { PluginCard } from "@/components/plugin-card"
 import type { PluginRecord } from "@/lib/plugin-schema"
-import type { CatalogDateField } from "../../plugin/shared/catalog"
 
 export function PluginGrid({
   plugins,
-  dateField,
+  showAddedDate,
 }: {
   plugins: PluginRecord[]
-  dateField?: CatalogDateField
+  showAddedDate?: boolean
 }) {
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
       {plugins.map((plugin) => (
-        <PluginCard key={plugin.id} plugin={plugin} dateField={dateField} />
+        <PluginCard
+          key={plugin.id}
+          plugin={plugin}
+          showAddedDate={showAddedDate}
+        />
       ))}
     </div>
   )

--- a/src/components/plugin-sidebar.tsx
+++ b/src/components/plugin-sidebar.tsx
@@ -70,7 +70,6 @@ export function PluginSidebar({ plugin }: { plugin: PluginRecord }) {
         ) : null}
         {plugin.license ? <span>License: {plugin.license}</span> : null}
         {plugin.author ? <span>By {plugin.author}</span> : null}
-        {plugin.version ? <span>Version: {plugin.version}</span> : null}
       </div>
 
       {plugin.categories.length > 0 ? (

--- a/src/components/plugin-sidebar.tsx
+++ b/src/components/plugin-sidebar.tsx
@@ -73,7 +73,7 @@ export function PluginSidebar({ plugin }: { plugin: PluginRecord }) {
         {plugin.author ? <span>By {plugin.author}</span> : null}
         {plugin.repoMeta ? (
           <span>
-            Last updated <ReaderDate iso={plugin.repoMeta.pushedAt} />
+            Last repository push <ReaderDate iso={plugin.repoMeta.pushedAt} />
           </span>
         ) : null}
       </div>

--- a/src/components/plugin-sidebar.tsx
+++ b/src/components/plugin-sidebar.tsx
@@ -8,9 +8,9 @@ import { Link } from "@tanstack/react-router"
 import { PluginHealthChecks } from "@/components/plugin-health-checks"
 import { PluginManifest } from "@/components/plugin-manifest"
 import { PluginSecurityScanSection } from "@/components/plugin-security-scan"
+import { ReaderDate } from "@/components/reader-date"
 import { Badge } from "@/components/ui/badge"
 import { HOME_SEARCH_DEFAULT } from "@/lib/catalog-search"
-import { formatDate } from "@/lib/format-date"
 import type { PluginRecord } from "@/lib/plugin-schema"
 import { pluginOwnerLogin } from "@/lib/plugin-schema"
 import { pluginRepositoryUrl } from "@/lib/plugin-source"
@@ -72,7 +72,9 @@ export function PluginSidebar({ plugin }: { plugin: PluginRecord }) {
         {plugin.license ? <span>License: {plugin.license}</span> : null}
         {plugin.author ? <span>By {plugin.author}</span> : null}
         {plugin.repoMeta ? (
-          <span>Last updated {formatDate(plugin.repoMeta.pushedAt)}</span>
+          <span>
+            Last updated <ReaderDate iso={plugin.repoMeta.pushedAt} />
+          </span>
         ) : null}
       </div>
 

--- a/src/components/plugin-sidebar.tsx
+++ b/src/components/plugin-sidebar.tsx
@@ -8,7 +8,6 @@ import { Link } from "@tanstack/react-router"
 import { PluginHealthChecks } from "@/components/plugin-health-checks"
 import { PluginManifest } from "@/components/plugin-manifest"
 import { PluginSecurityScanSection } from "@/components/plugin-security-scan"
-import { ReaderDate } from "@/components/reader-date"
 import { Badge } from "@/components/ui/badge"
 import { HOME_SEARCH_DEFAULT } from "@/lib/catalog-search"
 import type { PluginRecord } from "@/lib/plugin-schema"
@@ -71,11 +70,7 @@ export function PluginSidebar({ plugin }: { plugin: PluginRecord }) {
         ) : null}
         {plugin.license ? <span>License: {plugin.license}</span> : null}
         {plugin.author ? <span>By {plugin.author}</span> : null}
-        {plugin.repoMeta ? (
-          <span>
-            Last repository push <ReaderDate iso={plugin.repoMeta.pushedAt} />
-          </span>
-        ) : null}
+        {plugin.version ? <span>Version: {plugin.version}</span> : null}
       </div>
 
       {plugin.categories.length > 0 ? (

--- a/src/components/reader-date.tsx
+++ b/src/components/reader-date.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react"
+import {
+  formatCatalogDate,
+  formatCatalogDateForReader,
+} from "../../plugin/shared/catalog"
+
+/**
+ * A catalog date rendered in the reader's own locale and time zone.
+ *
+ * Neither is knowable during the server render, and formatting a date through
+ * Intl on the server and again in the browser is exactly the hydration
+ * mismatch this site hit before (see src/lib/format-date.ts). So both passes
+ * render the same locale-independent UTC form, and an effect — which only
+ * runs in the browser, after hydration has matched — swaps in the reader's
+ * rendering. Readers without JavaScript keep the UTC form, which is still a
+ * correct, readable date rather than an empty space.
+ *
+ * The machine-readable value stays in `dateTime` either way.
+ */
+export function ReaderDate({ iso }: { iso: string }) {
+  const [text, setText] = useState(() => formatCatalogDate(iso) ?? iso)
+
+  useEffect(() => {
+    setText(formatCatalogDateForReader(iso) ?? iso)
+  }, [iso])
+
+  return <time dateTime={iso}>{text}</time>
+}

--- a/src/lib/agent-content.ts
+++ b/src/lib/agent-content.ts
@@ -143,8 +143,7 @@ export function renderPluginMarkdown(
     `- README: ${plugin.health.hasReadme ? "present" : "not found"}`,
     `- License: ${plugin.health.hasLicense ? "present" : "not found"}`,
     `- Tests: ${plugin.health.hasTests ? "present" : "not detected"}`,
-    `- Typecheck script: ${plugin.health.hasTypecheckScript ? "present" : "not detected"}`,
-    `- Recent repository activity: ${plugin.health.updatedRecently ? "yes" : "no"}`
+    `- Typecheck script: ${plugin.health.hasTypecheckScript ? "present" : "not detected"}`
   )
 
   if (plugin.security?.status && plugin.security.status !== "unknown") {

--- a/src/lib/agent-content.ts
+++ b/src/lib/agent-content.ts
@@ -144,7 +144,7 @@ export function renderPluginMarkdown(
     `- License: ${plugin.health.hasLicense ? "present" : "not found"}`,
     `- Tests: ${plugin.health.hasTests ? "present" : "not detected"}`,
     `- Typecheck script: ${plugin.health.hasTypecheckScript ? "present" : "not detected"}`,
-    `- Recently updated: ${plugin.health.updatedRecently ? "yes" : "no"}`
+    `- Recent repository activity: ${plugin.health.updatedRecently ? "yes" : "no"}`
   )
 
   if (plugin.security?.status && plugin.security.status !== "unknown") {

--- a/src/lib/catalog-search.test.ts
+++ b/src/lib/catalog-search.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+import {
+  parseCatalogSearch,
+  sortLabels,
+  sortOptions,
+  sortPlugins,
+} from "./catalog-search"
+import type { PluginRecord } from "./plugin-schema"
+
+function plugin(
+  id: string,
+  overrides: Partial<PluginRecord> = {}
+): PluginRecord {
+  return {
+    id,
+    repo: `acme/${id}`,
+    url: `https://github.com/acme/${id}`,
+    name: id,
+    description: "",
+    categories: [],
+    platforms: [],
+    caveats: [],
+    health: {
+      manifestValid: true,
+      hasReadme: true,
+      hasLicense: true,
+      hasTests: true,
+      hasTypecheckScript: true,
+      updatedRecently: true,
+    },
+    images: [],
+    videos: [],
+    scannedAt: "2026-09-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("sortPlugins by listing date", () => {
+  it("puts the most recently listed plugin first", () => {
+    const sorted = sortPlugins(
+      [
+        plugin("older", { addedAt: "2026-01-05T00:00:00+00:00" }),
+        plugin("newest", { addedAt: "2026-09-05T00:00:00+00:00" }),
+        plugin("middle", { addedAt: "2026-05-05T00:00:00+00:00" }),
+      ],
+      "added"
+    )
+
+    expect(sorted.map((entry) => entry.id)).toEqual([
+      "newest",
+      "middle",
+      "older",
+    ])
+  })
+
+  it("sorts plugins with no known listing date last, by name", () => {
+    const sorted = sortPlugins(
+      [
+        plugin("unknown-b"),
+        plugin("listed", { addedAt: "2020-01-01T00:00:00+00:00" }),
+        plugin("unknown-a"),
+      ],
+      "added"
+    )
+
+    expect(sorted.map((entry) => entry.id)).toEqual([
+      "listed",
+      "unknown-a",
+      "unknown-b",
+    ])
+  })
+
+  it("ignores an unparseable date rather than ranking it highest", () => {
+    const sorted = sortPlugins(
+      [
+        plugin("broken", { addedAt: "not-a-date" }),
+        plugin("listed", { addedAt: "2026-02-02T00:00:00+00:00" }),
+      ],
+      "added"
+    )
+
+    expect(sorted.map((entry) => entry.id)).toEqual(["listed", "broken"])
+  })
+
+  it("offers the sort in the catalog UI and accepts it as a search param", () => {
+    expect(sortOptions).toContain("added")
+    expect(sortLabels.added).toBe("Recently added")
+    expect(parseCatalogSearch({ sort: "added" }).sort).toBe("added")
+  })
+})

--- a/src/lib/catalog-search.test.ts
+++ b/src/lib/catalog-search.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
   parseCatalogSearch,
-  sortDateField,
   sortLabels,
   sortOptions,
   sortPlugins,
@@ -83,19 +82,10 @@ describe("sortPlugins by listing date", () => {
     expect(sorted.map((entry) => entry.id)).toEqual(["listed", "broken"])
   })
 
-  it("offers the sort in the catalog UI and accepts it as a search param", () => {
-    expect(sortOptions).toContain("added")
+  it("offers listing-date sorting and retires repository-activity sorting", () => {
+    expect(sortOptions).toEqual(["popular", "added", "az"])
     expect(sortLabels.added).toBe("Recently added")
-    expect(sortLabels.updated).toBe("Recent repo activity")
     expect(parseCatalogSearch({ sort: "added" }).sort).toBe("added")
-  })
-})
-
-describe("sortDateField", () => {
-  it("labels the date each sort orders by, and no other", () => {
-    expect(sortDateField("added")).toBe("added")
-    expect(sortDateField("updated")).toBe("pushed")
-    expect(sortDateField("popular")).toBeUndefined()
-    expect(sortDateField("az")).toBeUndefined()
+    expect(parseCatalogSearch({ sort: "updated" }).sort).toBe("popular")
   })
 })

--- a/src/lib/catalog-search.test.ts
+++ b/src/lib/catalog-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   parseCatalogSearch,
+  sortDateField,
   sortLabels,
   sortOptions,
   sortPlugins,
@@ -86,5 +87,14 @@ describe("sortPlugins by listing date", () => {
     expect(sortOptions).toContain("added")
     expect(sortLabels.added).toBe("Recently added")
     expect(parseCatalogSearch({ sort: "added" }).sort).toBe("added")
+  })
+})
+
+describe("sortDateField", () => {
+  it("labels the date each sort orders by, and no other", () => {
+    expect(sortDateField("added")).toBe("added")
+    expect(sortDateField("updated")).toBe("updated")
+    expect(sortDateField("popular")).toBeUndefined()
+    expect(sortDateField("az")).toBeUndefined()
   })
 })

--- a/src/lib/catalog-search.test.ts
+++ b/src/lib/catalog-search.test.ts
@@ -86,6 +86,7 @@ describe("sortPlugins by listing date", () => {
   it("offers the sort in the catalog UI and accepts it as a search param", () => {
     expect(sortOptions).toContain("added")
     expect(sortLabels.added).toBe("Recently added")
+    expect(sortLabels.updated).toBe("Recent repo activity")
     expect(parseCatalogSearch({ sort: "added" }).sort).toBe("added")
   })
 })
@@ -93,7 +94,7 @@ describe("sortPlugins by listing date", () => {
 describe("sortDateField", () => {
   it("labels the date each sort orders by, and no other", () => {
     expect(sortDateField("added")).toBe("added")
-    expect(sortDateField("updated")).toBe("updated")
+    expect(sortDateField("updated")).toBe("pushed")
     expect(sortDateField("popular")).toBeUndefined()
     expect(sortDateField("az")).toBeUndefined()
   })

--- a/src/lib/catalog-search.ts
+++ b/src/lib/catalog-search.ts
@@ -89,7 +89,7 @@ export function clampCatalogPage(page: number, totalPages: number): number {
 
 export const sortLabels: Record<SortValue, string> = {
   popular: "Popular",
-  updated: "Recently updated",
+  updated: "Recent repo activity",
   added: CATALOG_ADDED_AT_LABEL,
   az: "A–Z",
 }
@@ -102,7 +102,7 @@ export const sortOptions: SortValue[] = ["popular", "updated", "added", "az"]
  */
 export function sortDateField(sort: SortValue): CatalogDateField | undefined {
   if (sort === "added") return "added"
-  if (sort === "updated") return "updated"
+  if (sort === "updated") return "pushed"
   return undefined
 }
 

--- a/src/lib/catalog-search.ts
+++ b/src/lib/catalog-search.ts
@@ -6,6 +6,10 @@ import {
   PLATFORMS,
   type Platform,
 } from "@/lib/registry-schema"
+import {
+  CATALOG_ADDED_AT_LABEL,
+  compareCatalogAddedAt,
+} from "../../plugin/shared/catalog"
 
 /**
  * Search-param shape, defaults, parsing, and sorting shared by the homepage
@@ -22,7 +26,7 @@ export const HOME_SEARCH_DEFAULT = {
   page: 1,
 } as const
 
-const sortValues = ["popular", "updated", "az"] as const
+const sortValues = ["popular", "updated", "added", "az"] as const
 export type SortValue = (typeof sortValues)[number]
 
 function normalizeCategoryFilter(category: string): Category | "" {
@@ -85,10 +89,11 @@ export function clampCatalogPage(page: number, totalPages: number): number {
 export const sortLabels: Record<SortValue, string> = {
   popular: "Popular",
   updated: "Recently updated",
+  added: CATALOG_ADDED_AT_LABEL,
   az: "A–Z",
 }
 
-export const sortOptions: SortValue[] = ["popular", "updated", "az"]
+export const sortOptions: SortValue[] = ["popular", "updated", "added", "az"]
 
 const collator = new Intl.Collator(undefined, {
   numeric: true,
@@ -116,6 +121,8 @@ export function sortPlugins(
             (Date.parse(a.repoMeta?.pushedAt ?? "") || 0) ||
           comparePluginsByName(a, b)
         )
+      case "added":
+        return compareCatalogAddedAt(a, b) || comparePluginsByName(a, b)
       case "az":
         return comparePluginsByName(a, b)
       default:

--- a/src/lib/catalog-search.ts
+++ b/src/lib/catalog-search.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/registry-schema"
 import {
   CATALOG_ADDED_AT_LABEL,
+  type CatalogDateField,
   compareCatalogAddedAt,
 } from "../../plugin/shared/catalog"
 
@@ -94,6 +95,16 @@ export const sortLabels: Record<SortValue, string> = {
 }
 
 export const sortOptions: SortValue[] = ["popular", "updated", "added", "az"]
+
+/**
+ * The date a listing should show while this sort is active — the value the
+ * ordering is actually based on. Sorts that don't order by a date show none.
+ */
+export function sortDateField(sort: SortValue): CatalogDateField | undefined {
+  if (sort === "added") return "added"
+  if (sort === "updated") return "updated"
+  return undefined
+}
 
 const collator = new Intl.Collator(undefined, {
   numeric: true,

--- a/src/lib/catalog-search.ts
+++ b/src/lib/catalog-search.ts
@@ -8,7 +8,6 @@ import {
 } from "@/lib/registry-schema"
 import {
   CATALOG_ADDED_AT_LABEL,
-  type CatalogDateField,
   compareCatalogAddedAt,
 } from "../../plugin/shared/catalog"
 
@@ -27,7 +26,7 @@ export const HOME_SEARCH_DEFAULT = {
   page: 1,
 } as const
 
-const sortValues = ["popular", "updated", "added", "az"] as const
+const sortValues = ["popular", "added", "az"] as const
 export type SortValue = (typeof sortValues)[number]
 
 function normalizeCategoryFilter(category: string): Category | "" {
@@ -89,22 +88,11 @@ export function clampCatalogPage(page: number, totalPages: number): number {
 
 export const sortLabels: Record<SortValue, string> = {
   popular: "Popular",
-  updated: "Recent repo activity",
   added: CATALOG_ADDED_AT_LABEL,
   az: "A–Z",
 }
 
-export const sortOptions: SortValue[] = ["popular", "updated", "added", "az"]
-
-/**
- * The date a listing should show while this sort is active — the value the
- * ordering is actually based on. Sorts that don't order by a date show none.
- */
-export function sortDateField(sort: SortValue): CatalogDateField | undefined {
-  if (sort === "added") return "added"
-  if (sort === "updated") return "pushed"
-  return undefined
-}
+export const sortOptions: SortValue[] = ["popular", "added", "az"]
 
 const collator = new Intl.Collator(undefined, {
   numeric: true,
@@ -124,12 +112,6 @@ export function sortPlugins(
       case "popular":
         return (
           (b.repoMeta?.stars ?? 0) - (a.repoMeta?.stars ?? 0) ||
-          comparePluginsByName(a, b)
-        )
-      case "updated":
-        return (
-          (Date.parse(b.repoMeta?.pushedAt ?? "") || 0) -
-            (Date.parse(a.repoMeta?.pushedAt ?? "") || 0) ||
           comparePluginsByName(a, b)
         )
       case "added":

--- a/src/lib/directory-api.ts
+++ b/src/lib/directory-api.ts
@@ -70,6 +70,9 @@ export const directoryPluginSchema = z.object({
   images: z.array(directoryImageUrlSchema).max(32),
   readmeText: z.string().max(MAX_API_README_TEXT_LENGTH).optional(),
   scanError: z.string().max(4_000).optional(),
+  // When the plugin was listed in the catalog — see PluginRecord.addedAt.
+  // The companion plugin sorts its "Recently added" view by this.
+  addedAt: z.iso.datetime({ offset: true }).optional(),
   scannedAt: z.string().max(100),
   health: pluginHealthSchema,
 })
@@ -139,6 +142,7 @@ export function projectPluginForDirectory(
     images: [],
     health: plugin.health,
     scannedAt: boundedString(plugin.scannedAt, 100),
+    ...(plugin.addedAt ? { addedAt: plugin.addedAt } : {}),
     ...(plugin.path ? { path: plugin.path } : {}),
     ...(version !== undefined ? { version } : {}),
     ...(security ? { security } : {}),

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,17 +1,4 @@
-const MONTHS = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-]
+import { formatCatalogDate } from "../../plugin/shared/catalog"
 
 function pad(n: number): string {
   return String(n).padStart(2, "0")
@@ -20,13 +7,14 @@ function pad(n: number): string {
 /**
  * `toLocaleDateString()`/`toLocaleString()` depend on the runtime's ICU data
  * and locale, which can (and did) differ between the Node SSR render and the
- * browser hydrating it, producing a React hydration mismatch. These format
- * dates by hand instead, using UTC fields, so the output is identical
- * everywhere regardless of server/browser locale or timezone.
+ * browser hydrating it, producing a React hydration mismatch. The shared
+ * formatter in plugin/shared/catalog.ts builds dates by hand from UTC fields
+ * instead, so the output is identical everywhere — and identical to the date
+ * the companion plugin renders for the same listing. An unparseable value is
+ * echoed back rather than rendered as "NaN NaN NaN".
  */
 export function formatDate(iso: string): string {
-  const d = new Date(iso)
-  return `${pad(d.getUTCDate())} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`
+  return formatCatalogDate(iso) ?? iso
 }
 
 export function formatDateTime(iso: string): string {

--- a/src/lib/json-ld.test.ts
+++ b/src/lib/json-ld.test.ts
@@ -46,6 +46,27 @@ describe("pluginJsonLd", () => {
     })
   })
 
+  it("publishes the semantic version and catalog date, not repository activity", () => {
+    const ld = pluginJsonLd({
+      ...basePlugin,
+      version: "1.2.3",
+      addedAt: "2026-09-11T12:00:00Z",
+      repoMeta: {
+        stars: 1,
+        openIssues: 0,
+        defaultBranch: "main",
+        pushedAt: "2026-09-12T12:00:00Z",
+        topics: [],
+        archived: false,
+        license: "MIT",
+      },
+    })
+
+    expect(ld.softwareVersion).toBe("1.2.3")
+    expect(ld.datePublished).toBe("2026-09-11T12:00:00Z")
+    expect(ld).not.toHaveProperty("dateModified")
+  })
+
   it("falls back to the generated OG image when there are no screenshots", () => {
     const ld = pluginJsonLd(basePlugin)
     expect(ld.image).toContain("/og/subagent-activity.png")

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -27,6 +27,7 @@ export function pluginJsonLd(plugin: PluginRecord) {
     license: plugin.license
       ? `https://spdx.org/licenses/${plugin.license}.html`
       : undefined,
+    datePublished: plugin.addedAt,
     dateModified: plugin.repoMeta?.pushedAt,
     author: plugin.owner
       ? { "@type": "Person", name: plugin.owner.login, url: plugin.owner.url }

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -28,7 +28,6 @@ export function pluginJsonLd(plugin: PluginRecord) {
       ? `https://spdx.org/licenses/${plugin.license}.html`
       : undefined,
     datePublished: plugin.addedAt,
-    dateModified: plugin.repoMeta?.pushedAt,
     author: plugin.owner
       ? { "@type": "Person", name: plugin.owner.login, url: plugin.owner.url }
       : undefined,

--- a/src/lib/plugin-schema.ts
+++ b/src/lib/plugin-schema.ts
@@ -158,6 +158,12 @@ export const pluginRecordSchema = z.object({
   images: z.array(z.string()).default([]),
   videos: z.array(videoEmbedSchema).default([]),
   scanError: z.string().optional(),
+  // When this plugin's registry entry first landed in this repo's git history
+  // — the catalog's "added" date, derived at scan time (see
+  // readRegistryAddedAt in scripts/scan.ts) rather than hand-authored.
+  // Optional: an entry that isn't committed yet, or a shallow checkout, has
+  // no history to read, and an unknown date is left unknown.
+  addedAt: z.iso.datetime({ offset: true }).optional(),
   scannedAt: z.string(),
 })
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -161,7 +161,7 @@ function App() {
     () => sortPlugins(plugins, "popular").slice(0, SECTION_LIMIT),
     [plugins]
   )
-  const recentlyUpdated = useMemo(
+  const recentRepositoryActivity = useMemo(
     () => sortPlugins(plugins, "updated").slice(0, SECTION_LIMIT),
     [plugins]
   )
@@ -237,9 +237,9 @@ function App() {
                 plugins={popular}
               />
               <FeaturedSection
-                title="Recently updated"
-                description="Plugins with recent repository activity."
-                plugins={recentlyUpdated}
+                title="Recent repo activity"
+                description="Plugins whose source repositories were pushed recently."
+                plugins={recentRepositoryActivity}
               />
               <FeaturedSection
                 title="Recently added"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -161,10 +161,6 @@ function App() {
     () => sortPlugins(plugins, "popular").slice(0, SECTION_LIMIT),
     [plugins]
   )
-  const recentRepositoryActivity = useMemo(
-    () => sortPlugins(plugins, "updated").slice(0, SECTION_LIMIT),
-    [plugins]
-  )
   // Only plugins with a known listing date: without git history to derive it
   // from (see readRegistryAddedAt in scripts/scan.ts) this section stays
   // empty rather than presenting an arbitrary order as "newest".
@@ -235,11 +231,6 @@ function App() {
                 title="Popular"
                 description="Most starred plugins right now."
                 plugins={popular}
-              />
-              <FeaturedSection
-                title="Recent repo activity"
-                description="Plugins whose source repositories were pushed recently."
-                plugins={recentRepositoryActivity}
               />
               <FeaturedSection
                 title="Recently added"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -165,6 +165,17 @@ function App() {
     () => sortPlugins(plugins, "updated").slice(0, SECTION_LIMIT),
     [plugins]
   )
+  // Only plugins with a known listing date: without git history to derive it
+  // from (see readRegistryAddedAt in scripts/scan.ts) this section stays
+  // empty rather than presenting an arbitrary order as "newest".
+  const recentlyAdded = useMemo(
+    () =>
+      sortPlugins(
+        plugins.filter((plugin) => plugin.addedAt),
+        "added"
+      ).slice(0, SECTION_LIMIT),
+    [plugins]
+  )
   const showFeatured = !hasFilters && search.sort === "popular" && page === 1
 
   const summary = hasFilters
@@ -229,6 +240,11 @@ function App() {
                 title="Recently updated"
                 description="Plugins with recent repository activity."
                 plugins={recentlyUpdated}
+              />
+              <FeaturedSection
+                title="Recently added"
+                description="The newest listings in the directory."
+                plugins={recentlyAdded}
               />
             </div>
           ) : null}


### PR DESCRIPTION
## Problem

The catalog cannot show when a plugin was accepted. A plugin listed yesterday looks the same as one present since launch.

## Catalog-owned listing date

`scripts/scan.ts` derives `addedAt` from the first commit on the catalog branch's first-parent history that added each `registry/*.json` entry. Merge commits are diffed against their first parent, so a contributor's preserved commit date cannot move a listing forward. Future and non-positive timestamps are treated as unknown.

The value is derived rather than submitted: existing entries receive historical dates, later registry edits do not re-date them, and submitters cannot choose their position. Shallow or history-less checkouts produce no date rather than a false one; scanner workflows therefore use full history.

## Website and companion

- Add a **Recently added** sort and homepage/highlight section.
- Show the listing date while results are ordered by it.
- Carry optional `addedAt` through the public API and companion schema.
- Hide highlight sections after the user selects another sort or filter.
- Render reader-facing dates in the reader's locale after hydration, with a deterministic UTC fallback.
- Publish `addedAt` as JSON-LD `datePublished`.

## Semver is the update source of truth

PR #89 made `package.json.version` the plugin update identity, and main now owns consistent version rendering across website and companion surfaces. This PR keeps those canonical surfaces unchanged and adds listing-date discovery alongside them:

- Website sort options are Popular, Recently added, and A–Z. Legacy `sort=updated` URLs safely fall back to Popular.
- The companion keeps **Updates first**, driven by installed-versus-catalog semver, plus Popular, Recently added, and A–Z.
- Existing persisted companion `recent` sort settings migrate to Updates first.
- Repository push timestamps are not shown as update dates, used for ordering, or published as JSON-LD `dateModified`/sitemap `lastmod`.

Repository activity remains available as backward-compatible catalog metadata, but it does not drive user-facing update or discovery behavior.

## Verification

- Rebased onto current `main`, including the shared version surfaces from #94.
- Website configured suite: 214 tests passed.
- Website TypeScript, changed-source Biome, production build, and fork-base-path build: passed.
- Companion TypeScript: passed.
- Companion suite: 104 tests passed.
- Production build: passed, 213 routes prerendered.
- Browser validation: Recently added shows Added dates, each card uses main's single canonical version badge, repository-activity controls are absent, and legacy `sort=updated` falls back to Popular.