### PR TITLE
feat(catalog): add semver-based plugin update detection

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,18 +2,18 @@
 
 <!-- Describe the catalog or site change. -->
 
-## Plugin submissions and updates
+## Plugin submissions and registry changes
 
 <!-- Delete this section when the pull request does not change registry/*.json. -->
 
 - [ ] `paseo-plugin.json.id` matches the registry filename.
-- [ ] `package.json.version` is a released semantic version, not `0.0.0`.
-- [ ] If this accompanies a plugin-code release, `package.json.version` was incremented.
+- [ ] For a new plugin submission, `package.json.version` is a released semantic version, not `0.0.0`.
 - [ ] The repository and plugin path are public.
 
-The companion catalog uses `package.json.version` as the plugin's update identity. Missing or invalid
-versions appear as unavailable. The scanner flags `0.0.0`, because updates cannot be detected until
-the maintainer starts incrementing it.
+Plugin releases do not require a Paseo Cafe PR. The catalog scanner reads releases from the plugin
+repository automatically. The companion catalog uses `package.json.version` as the plugin's update
+identity, so maintainers must increment it for each plugin-code release. Missing or invalid versions
+appear as unavailable; the scanner flags `0.0.0`.
 
 ## Verification
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## What changed
+
+<!-- Describe the catalog or site change. -->
+
+## Plugin submissions and updates
+
+<!-- Delete this section when the pull request does not change registry/*.json. -->
+
+- [ ] `paseo-plugin.json.id` matches the registry filename.
+- [ ] `package.json.version` is a released semantic version, not `0.0.0`.
+- [ ] For an existing plugin, `package.json.version` was incremented for this release.
+- [ ] The repository and plugin path are public.
+
+The companion catalog uses `package.json.version` as the plugin's update identity. Missing or invalid
+versions appear as unavailable. The scanner flags `0.0.0`, because updates cannot be detected until
+the maintainer starts incrementing it.
+
+## Verification
+
+<!-- List the commands or scenarios used to verify this change. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 - [ ] `paseo-plugin.json.id` matches the registry filename.
 - [ ] `package.json.version` is a released semantic version, not `0.0.0`.
-- [ ] For an existing plugin, `package.json.version` was incremented for this release.
+- [ ] If this accompanies a plugin-code release, `package.json.version` was incremented.
 - [ ] The repository and plugin path are public.
 
 The companion catalog uses `package.json.version` as the plugin's update identity. Missing or invalid

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,12 @@ the other by hand**:
    do) is expected and fine — keep any such shared module free of anything
    that would make it fail to typecheck under the website's DOM-ful config.
 
+4. **Plugin release identity.** The catalog and companion plugin use each plugin's
+   `package.json.version` as its update identity. Registry submissions must use a real semantic
+   version rather than `0.0.0`, and every released plugin change must increment it. Keep this
+   contract visible in submitter-facing guidance and templates; the registry scanner must flag
+   placeholder versions.
+
 **Validate both sides before calling catalog/plugin work done:**
 ```bash
 bun run check                                  # website: biome + tsc

--- a/README.md
+++ b/README.md
@@ -71,14 +71,17 @@ Requirements, checked automatically by CI:
   validation applied by both the site and companion plugin.
 - Your repo (at `path`, if given) contains a valid `paseo-plugin.json` with the same `id`.
 
-The plugin name comes from the registry filename after it is validated against the manifest ID. Description, version, license, screenshots,
-stars, and the best-effort limitations excerpt are read from the plugin repository automatically.
-A `README.md`, `LICENSE`, and an `images/` folder with screenshots all make a listing better; none
-are required to get in.
+The plugin name comes from the registry filename after it is validated against the manifest ID.
+Description, version, license, screenshots, stars, and the best-effort limitations excerpt are read
+from the plugin repository automatically. A `README.md`, `LICENSE`, and an `images/` folder with
+screenshots all make a listing better; none are required to get in.
 
-Paseo Cafe uses the plugin directory's own `package.json` version as its update signal. Keep that
-field on valid semver and bump it when the plugin changes. Missing or invalid versions remain
-browsable and installable, but the companion plugin will not claim that an update is available.
+Paseo Cafe uses the plugin directory's own `package.json.version` as its update identity. Start at a
+real semantic version such as `0.1.0`, not the `0.0.0` placeholder, and increment it whenever you
+publish a plugin update. Missing or invalid versions remain browsable and installable but report
+their version as unavailable. The scanner flags `0.0.0`, because updates cannot be detected until
+the maintainer starts incrementing it.
+
 
 Open a PR adding your `registry/<id>.json`. Once Registry validation and CI pass, it's ready to merge.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ stars, and the best-effort limitations excerpt are read from the plugin reposito
 A `README.md`, `LICENSE`, and an `images/` folder with screenshots all make a listing better; none
 are required to get in.
 
+Paseo Cafe uses the plugin directory's own `package.json` version as its update signal. Keep that
+field on valid semver and bump it when the plugin changes. Missing or invalid versions remain
+browsable and installable, but the companion plugin will not claim that an update is available.
+
 Open a PR adding your `registry/<id>.json`. Once Registry validation and CI pass, it's ready to merge.
 
 ## Local development

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,9 +10,11 @@ on the daemon host behind a confirmation step. A **Paseo plugin** composer attac
 lets you attach a plugin's full listing to a prompt when you want an agent to review it before
 you trust it.
 
-Update availability is based on each plugin directory's `package.json` semver, not on repository
-HEAD. An unrelated monorepo commit therefore does not mark every plugin as outdated. A missing or
-invalid installed or catalog version leaves update status unavailable rather than guessing.
+Update availability is based on each plugin directory's `package.json` semver. An unrelated
+monorepo commit therefore does not mark every plugin as outdated. A missing or invalid installed
+or catalog version leaves update status unavailable rather than guessing. Until Paseo supports
+explicit-ref updates, applying an update still installs the tracked branch's current HEAD, which
+may be newer than the commit scanned by the catalog.
 
 ## Screenshots
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,6 +10,10 @@ on the daemon host behind a confirmation step. A **Paseo plugin** composer attac
 lets you attach a plugin's full listing to a prompt when you want an agent to review it before
 you trust it.
 
+Update availability is based on each plugin directory's `package.json` semver, not on repository
+HEAD. An unrelated monorepo commit therefore does not mark every plugin as outdated. A missing or
+invalid installed or catalog version leaves update status unavailable rather than guessing.
+
 ## Screenshots
 
 ### Browse and filter the catalog
@@ -43,6 +47,8 @@ daemon host.
 - Plugins listed here are community-submitted and are not vetted by paseo.cafe. They are
   trusted, unsandboxed code on your daemon host: read the source before installing.
 - Installing shells out to the `paseo` CLI, so that binary must be on the daemon's `PATH`.
+- Git installs and updates of this companion plugin run `npm ci --omit=dev` so its server-side
+  semver dependency is available in the managed checkout.
 - The composer attachment source always searches the default catalog. Paseo calls an
   attachment search with the query alone, and a plugin's server handler cannot read its own
   settings, so a custom Catalog URL applies to the sidebar surface only.

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -499,14 +499,12 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
     entryId: string
     message: string
   } | null>(null)
-  const [detailEntry, setDetailEntry] = useState<DirectoryEntry | null>(null)
   const [galleryEntry, setGalleryEntry] = useState<DirectoryEntry | null>(null)
   const [lastOpenedPluginId, setLastOpenedPluginId] = useState<string | null>(
     null
   )
   const [settingsHydrated, setSettingsHydrated] = useState(false)
   const hasHydratedSettings = useRef(false)
-  const hasRestoredLastOpened = useRef(false)
 
   const settingsValues = settings.status === "ready" ? settings.values : null
   const settingsRevision =
@@ -668,6 +666,7 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
           repo: entry.repo,
           path: entry.path,
           version: entry.version,
+          ref: entry.repoMeta?.defaultBranch,
         },
       }) as Promise<UpdateResult>
     },
@@ -745,20 +744,9 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       })),
     [catalogPlugins]
   )
-  useEffect(() => {
-    if (
-      !settingsHydrated ||
-      hasRestoredLastOpened.current ||
-      !directoryQuery.isSuccess
-    ) {
-      return
-    }
-
-    hasRestoredLastOpened.current = true
-    if (!lastOpenedPluginId) return
-    const lastOpened = plugins.find((entry) => entry.id === lastOpenedPluginId)
-    if (lastOpened) setDetailEntry(lastOpened)
-  }, [directoryQuery.isSuccess, lastOpenedPluginId, plugins, settingsHydrated])
+  const detailEntry = lastOpenedPluginId
+    ? (plugins.find((entry) => entry.id === lastOpenedPluginId) ?? null)
+    : null
   const installations = inventoryAvailable
     ? (updateStatusQuery.data?.installations ??
       directoryQuery.data?.installations ??
@@ -929,7 +917,6 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
   )
 
   function openPlugin(entry: DirectoryEntry) {
-    setDetailEntry(entry)
     setLastOpenedPluginId(entry.id)
   }
 
@@ -1103,7 +1090,6 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
         onOpenGallery={() => setGalleryEntry(detailEntry)}
         onBack={() => {
           setLastOpenedPluginId(null)
-          setDetailEntry(null)
         }}
       />
     )

--- a/plugin/client/DirectorySurface.tsx
+++ b/plugin/client/DirectorySurface.tsx
@@ -663,7 +663,12 @@ export function DirectorySurface({ theme, layout }: PluginSurfaceProps) {
       setUpdateFailure(null)
       return updatePlugin({
         pluginId: installation.id,
-        entry: { id: entry.id, repo: entry.repo, path: entry.path },
+        entry: {
+          id: entry.id,
+          repo: entry.repo,
+          path: entry.path,
+          version: entry.version,
+        },
       }) as Promise<UpdateResult>
     },
     onSuccess: async (

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -8,11 +8,15 @@
       "name": "paseo-cafe-plugin",
       "version": "0.3.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^7.7.3"
+      },
       "devDependencies": {
         "@getpaseo/plugin": "0.8.0",
         "@tanstack/react-query": "^5.90.11",
         "@types/node": "^22",
         "@types/react": "~19.2.0",
+        "@types/semver": "^7.7.1",
         "react": "19.1.0",
         "react-native": "0.81.5",
         "typescript": "^5.9.3",
@@ -1388,6 +1392,13 @@
       "dependencies": {
         "csstype": "^3.2.2"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -4288,7 +4299,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -13,10 +13,14 @@
     "@tanstack/react-query": "^5.90.11",
     "@types/node": "^22",
     "@types/react": "~19.2.0",
+    "@types/semver": "^7.7.1",
     "react": "19.1.0",
     "react-native": "0.81.5",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0",
     "zod": "^4.4.3"
+  },
+  "dependencies": {
+    "semver": "^7.7.3"
   }
 }

--- a/plugin/paseo-plugin.json
+++ b/plugin/paseo-plugin.json
@@ -2,5 +2,6 @@
   "id": "paseo-cafe",
   "requirements": {
     "paseo": "^0.8.0"
-  }
+  },
+  "build": [["npm", "ci", "--omit=dev"]]
 }

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { delimiter, join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -16,6 +16,7 @@ import {
   installDirectoryPlugin,
   listDirectory,
   mapWithConcurrency,
+  readInstalledPluginVersion,
   remoteBranchMatchesCommit,
   searchDirectory,
   searchDirectoryManifests,
@@ -57,6 +58,7 @@ function gitInstallation(
     remote: "https://github.com/acme/plugins.git",
     ref: "main",
     commit: CURRENT,
+    version: "1.2.3",
     updateState: "unknown",
     ...overrides,
   }
@@ -556,6 +558,41 @@ describe("catalog installation matching", () => {
   })
 })
 
+describe("installed package version", () => {
+  it("reads valid semver from root and monorepo plugin paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "paseo-cafe-versions-"))
+    const nested = join(root, "plugins", "review")
+    await mkdir(nested, { recursive: true })
+    try {
+      await writeFile(join(root, "package.json"), '{"version":"1.2.3"}')
+      await writeFile(
+        join(nested, "package.json"),
+        '{"version":"2.0.0-beta.1"}'
+      )
+
+      await expect(readInstalledPluginVersion(root)).resolves.toBe("1.2.3")
+      await expect(readInstalledPluginVersion(nested)).resolves.toBe(
+        "2.0.0-beta.1"
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("omits missing and invalid package versions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "paseo-cafe-versions-"))
+    try {
+      await writeFile(join(root, "package.json"), '{"version":"not-semver"}')
+      await expect(readInstalledPluginVersion(root)).resolves.toBeUndefined()
+      await expect(
+        readInstalledPluginVersion(join(root, "missing"))
+      ).resolves.toBeUndefined()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe("update status classification", () => {
   it("keeps tags and commits pinned when no tracked branch existed at install", async () => {
     const runGit = vi
@@ -565,6 +602,7 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation({ ref: "v1.0.0" }),
+      { version: "1.3.0" },
       runGit
     )
 
@@ -578,26 +616,17 @@ describe("update status classification", () => {
       .mockResolvedValueOnce({ stdout: "", exitCode: 1 })
       .mockResolvedValueOnce({ stdout: "", exitCode: 1 })
 
-    const result = await inspectUpdateStatus(gitInstallation(), runGit)
+    const result = await inspectUpdateStatus(
+      gitInstallation(),
+      { version: "1.3.0" },
+      runGit
+    )
 
     expect(result.updateState).toBe("unknown")
     expect(result.updateError).toContain("Tracked branch is unavailable")
   })
 
-  it("reports current only after fetching and resolving the tracked branch", async () => {
-    const runGit = vi
-      .fn()
-      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
-      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
-      .mockResolvedValueOnce({ stdout: `${CURRENT}\n`, exitCode: 0 })
-
-    const result = await inspectUpdateStatus(gitInstallation(), runGit)
-
-    expect(result.updateState).toBe("current")
-    expect(result.latestCommit).toBe(CURRENT)
-  })
-
-  it("offers an update only when the installed commit is an ancestor", async () => {
+  it("ignores a monorepo HEAD change when the target plugin version is unchanged", async () => {
     const runGit = vi
       .fn()
       .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
@@ -605,13 +634,76 @@ describe("update status classification", () => {
       .mockResolvedValueOnce({ stdout: `${LATEST}\n`, exitCode: 0 })
       .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
 
-    const result = await inspectUpdateStatus(gitInstallation(), runGit)
+    const result = await inspectUpdateStatus(
+      gitInstallation({ version: "1.2.3" }),
+      { version: "1.2.3" },
+      runGit
+    )
 
-    expect(result.updateState).toBe("available")
+    expect(result.updateState).toBe("current")
     expect(result.latestCommit).toBe(LATEST)
+    expect(runGit).toHaveBeenCalledTimes(4)
   })
 
-  it("does not offer an update for a diverged source", async () => {
+  it("offers an update when the target plugin package version advances", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: `${LATEST}\n`, exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+
+    const result = await inspectUpdateStatus(
+      gitInstallation({ version: "1.2.3" }),
+      { version: "1.3.0" },
+      runGit
+    )
+
+    expect(result.updateState).toBe("available")
+  })
+
+  it("uses full semver precedence for prereleases", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: `${LATEST}\n`, exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+
+    const result = await inspectUpdateStatus(
+      gitInstallation({ version: "2.0.0-beta.1" }),
+      { version: "2.0.0" },
+      runGit
+    )
+
+    expect(result.updateState).toBe("available")
+  })
+
+  it("does not offer updates when either package version is missing or invalid", async () => {
+    for (const [installedVersion, catalogVersion] of [
+      [undefined, "1.3.0"],
+      ["not-semver", "1.3.0"],
+      ["1.2.3", undefined],
+      ["1.2.3", "not-semver"],
+    ] as const) {
+      const runGit = vi
+        .fn()
+        .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+        .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+        .mockResolvedValueOnce({ stdout: `${LATEST}\n`, exitCode: 0 })
+        .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      const result = await inspectUpdateStatus(
+        gitInstallation({ version: installedVersion }),
+        { version: catalogVersion },
+        runGit
+      )
+
+      expect(result.updateState).toBe("unknown")
+      expect(result.updateError).toBeUndefined()
+    }
+  })
+
+  it("preserves divergence even when the package version is unchanged", async () => {
     const runGit = vi
       .fn()
       .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
@@ -619,15 +711,40 @@ describe("update status classification", () => {
       .mockResolvedValueOnce({ stdout: `${LATEST}\n`, exitCode: 0 })
       .mockResolvedValueOnce({ stdout: "", exitCode: 1 })
 
-    const result = await inspectUpdateStatus(gitInstallation(), runGit)
+    const result = await inspectUpdateStatus(
+      gitInstallation(),
+      { version: "1.2.3" },
+      runGit
+    )
 
     expect(result.updateState).toBe("diverged")
   })
 
+  it("does not report an error when a newer catalog version points at the installed commit", async () => {
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: `${CURRENT}\n`, exitCode: 0 })
+
+    const result = await inspectUpdateStatus(
+      gitInstallation(),
+      { version: "1.3.0" },
+      runGit
+    )
+
+    expect(result.updateState).toBe("current")
+    expect(result.updateError).toBeUndefined()
+  })
+
   it("preserves an explicit unknown state when the remote check fails", async () => {
-    const result = await inspectUpdateStatus(gitInstallation(), async () => {
-      throw new Error("offline")
-    })
+    const result = await inspectUpdateStatus(
+      gitInstallation(),
+      { version: "1.3.0" },
+      async () => {
+        throw new Error("offline")
+      }
+    )
 
     expect(result.updateState).toBe("unknown")
     expect(result.updateError).toContain("offline")

--- a/plugin/server/directory.test.ts
+++ b/plugin/server/directory.test.ts
@@ -63,6 +63,9 @@ function gitInstallation(
     ...overrides,
   }
 }
+function catalogTarget(version: string | undefined, ref = "main") {
+  return { ref, version }
+}
 
 afterEach(() => {
   globalThis.fetch = originalFetch
@@ -579,10 +582,15 @@ describe("installed package version", () => {
     }
   })
 
-  it("omits missing and invalid package versions", async () => {
+  it("omits missing, invalid, and overlong package versions", async () => {
     const root = await mkdtemp(join(tmpdir(), "paseo-cafe-versions-"))
     try {
       await writeFile(join(root, "package.json"), '{"version":"not-semver"}')
+      await expect(readInstalledPluginVersion(root)).resolves.toBeUndefined()
+      await writeFile(
+        join(root, "package.json"),
+        JSON.stringify({ version: `1.0.0-${"a".repeat(95)}` })
+      )
       await expect(readInstalledPluginVersion(root)).resolves.toBeUndefined()
       await expect(
         readInstalledPluginVersion(join(root, "missing"))
@@ -602,7 +610,7 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation({ ref: "v1.0.0" }),
-      { version: "1.3.0" },
+      catalogTarget("1.3.0"),
       runGit
     )
 
@@ -618,12 +626,26 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation(),
-      { version: "1.3.0" },
+      catalogTarget("1.3.0"),
       runGit
     )
 
     expect(result.updateState).toBe("unknown")
     expect(result.updateError).toContain("Tracked branch is unavailable")
+  })
+
+  it("does not compare the catalog version against a different tracked branch", async () => {
+    const runGit = vi.fn().mockResolvedValueOnce({ stdout: "", exitCode: 0 })
+
+    const result = await inspectUpdateStatus(
+      gitInstallation({ ref: "stable" }),
+      catalogTarget("2.0.0"),
+      runGit
+    )
+
+    expect(result.updateState).toBe("unknown")
+    expect(result.updateError).toBeUndefined()
+    expect(runGit).toHaveBeenCalledTimes(1)
   })
 
   it("ignores a monorepo HEAD change when the target plugin version is unchanged", async () => {
@@ -636,7 +658,7 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation({ version: "1.2.3" }),
-      { version: "1.2.3" },
+      catalogTarget("1.2.3"),
       runGit
     )
 
@@ -655,7 +677,7 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation({ version: "1.2.3" }),
-      { version: "1.3.0" },
+      catalogTarget("1.3.0"),
       runGit
     )
 
@@ -672,7 +694,7 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation({ version: "2.0.0-beta.1" }),
-      { version: "2.0.0" },
+      catalogTarget("2.0.0"),
       runGit
     )
 
@@ -694,7 +716,7 @@ describe("update status classification", () => {
         .mockResolvedValueOnce({ stdout: "", exitCode: 0 })
       const result = await inspectUpdateStatus(
         gitInstallation({ version: installedVersion }),
-        { version: catalogVersion },
+        catalogTarget(catalogVersion),
         runGit
       )
 
@@ -713,7 +735,7 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation(),
-      { version: "1.2.3" },
+      catalogTarget("1.2.3"),
       runGit
     )
 
@@ -729,7 +751,7 @@ describe("update status classification", () => {
 
     const result = await inspectUpdateStatus(
       gitInstallation(),
-      { version: "1.3.0" },
+      catalogTarget("1.3.0"),
       runGit
     )
 
@@ -740,7 +762,7 @@ describe("update status classification", () => {
   it("preserves an explicit unknown state when the remote check fails", async () => {
     const result = await inspectUpdateStatus(
       gitInstallation(),
-      { version: "1.3.0" },
+      catalogTarget("1.3.0"),
       async () => {
         throw new Error("offline")
       }

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -1,7 +1,10 @@
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 import { promisify } from "node:util"
 import type { RpcInput, RpcOutput } from "@getpaseo/plugin"
+import * as semver from "semver"
 import { z } from "zod"
 import { getCatalogInstallArgs } from "../shared/catalog"
 import type {
@@ -155,8 +158,13 @@ async function execGit(
 
 type GitRunner = typeof execGit
 
+/**
+ * Retains the Git safety checks for tracked sources, but only reports an
+ * available update when the catalog package version is valid and greater.
+ */
 export async function inspectUpdateStatus(
   installation: InstalledPlugin,
+  entry: Pick<DirectoryEntry, "version">,
   runGit: GitRunner = execGit
 ): Promise<InstalledPlugin> {
   if (
@@ -191,6 +199,7 @@ export async function inspectUpdateStatus(
     }
     if (tracked.exitCode !== 0)
       throw new Error("Could not inspect tracked branch")
+
     const fetched = await runGit(
       installation.path,
       ["fetch", "--prune", "--tags", "origin"],
@@ -206,19 +215,39 @@ export async function inspectUpdateStatus(
     if (latest.exitCode !== 0 || !/^[0-9a-f]{40,64}$/i.test(latestCommit)) {
       throw new Error("Could not resolve tracked branch")
     }
+
+    const installedVersion = semver.valid(installation.version ?? "")
+    const latestVersion = semver.valid(entry.version ?? "")
     if (latestCommit === installation.commit) {
-      return { ...installation, latestCommit, updateState: "current" }
+      return {
+        ...installation,
+        version: installedVersion ?? installation.version,
+        latestCommit,
+        updateState: installedVersion && latestVersion ? "current" : "unknown",
+      }
     }
+
     const ancestor = await runGit(installation.path, [
       "merge-base",
       "--is-ancestor",
       installation.commit,
       latestCommit,
     ])
+    if (ancestor.exitCode !== 0) {
+      return { ...installation, latestCommit, updateState: "diverged" }
+    }
+    // Legacy installs and custom catalogs may not carry a valid version. Keep
+    // them usable, but never infer an update from a repository commit alone.
+    if (!installedVersion || !latestVersion) {
+      return { ...installation, latestCommit, updateState: "unknown" }
+    }
     return {
       ...installation,
+      version: installedVersion,
       latestCommit,
-      updateState: ancestor.exitCode === 0 ? "available" : "diverged",
+      updateState: semver.gt(latestVersion, installedVersion)
+        ? "available"
+        : "current",
     }
   } catch (error) {
     return {
@@ -230,22 +259,23 @@ export async function inspectUpdateStatus(
 }
 
 async function cachedUpdateStatus(
-  installation: InstalledPlugin
+  installation: InstalledPlugin,
+  entry: Pick<DirectoryEntry, "version">
 ): Promise<InstalledPlugin> {
-  const key = `${installation.path}\u0000${installation.ref ?? ""}\u0000${installation.commit ?? ""}`
+  const key = `${installation.path}\u0000${installation.ref ?? ""}\u0000${installation.commit ?? ""}\u0000${installation.version ?? ""}\u0000${entry.version ?? ""}`
   const now = Date.now()
   const cached = updateStatusCache.get(key)
   if (cached && cached.expiresAt > now) return cached.value
   if (updateStatusCache.size >= 500) {
-    for (const [cachedKey, entry] of updateStatusCache) {
-      if (entry.expiresAt <= now) updateStatusCache.delete(cachedKey)
+    for (const [cachedKey, cachedEntry] of updateStatusCache) {
+      if (cachedEntry.expiresAt <= now) updateStatusCache.delete(cachedKey)
     }
     if (updateStatusCache.size >= 500) {
       const oldestKey = updateStatusCache.keys().next().value
       if (oldestKey !== undefined) updateStatusCache.delete(oldestKey)
     }
   }
-  const value = inspectUpdateStatus(installation)
+  const value = inspectUpdateStatus(installation, entry)
   updateStatusCache.set(key, { expiresAt: now + UPDATE_STATUS_TTL_MS, value })
   return value
 }
@@ -273,17 +303,21 @@ async function addUpdateStatus(
   plugins: readonly DirectoryEntry[],
   installations: readonly InstalledPlugin[]
 ): Promise<InstalledPlugin[]> {
-  const matched = new Map<string, InstalledPlugin>()
+  const matched = new Map<
+    string,
+    { installation: InstalledPlugin; entry: DirectoryEntry }
+  >()
   for (const entry of plugins) {
     for (const installation of findInstallations(entry, installations)) {
-      if (installation.source === "git")
-        matched.set(installation.id, installation)
+      if (installation.source === "git") {
+        matched.set(installation.id, { installation, entry })
+      }
     }
   }
   const checked = await mapWithConcurrency(
     [...matched.values()],
     UPDATE_CHECK_CONCURRENCY,
-    cachedUpdateStatus
+    ({ installation, entry }) => cachedUpdateStatus(installation, entry)
   )
   const byId = new Map(
     checked.map((installation) => [installation.id, installation])
@@ -315,9 +349,33 @@ function commandFailureMessage(error: unknown): string {
     : message
 }
 
+export async function readInstalledPluginVersion(
+  directory: string
+): Promise<string | undefined> {
+  try {
+    const contents = JSON.parse(
+      await readFile(join(directory, "package.json"), "utf8")
+    ) as { version?: unknown }
+    return typeof contents.version === "string"
+      ? (semver.valid(contents.version) ?? undefined)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
 async function listInstalledPlugins() {
   const { stdout } = await execPaseo(["plugin", "ls", "--json"], 30_000)
-  return z.array(installedPluginSchema).max(500).parse(JSON.parse(stdout))
+  const installations = z
+    .array(installedPluginSchema)
+    .max(500)
+    .parse(JSON.parse(stdout))
+  return Promise.all(
+    installations.map(async (installation) => {
+      const version = await readInstalledPluginVersion(installation.path)
+      return version === undefined ? installation : { ...installation, version }
+    })
+  )
 }
 
 // Keyed by resolved URL so switching the directorySettings override (e.g. to
@@ -829,7 +887,7 @@ export async function updateDirectoryPlugin(
         message: `Installed plugin ${pluginId} does not match ${entry.repo}${entry.path ? `/${entry.path}` : ""}.`,
       }
     }
-    const checked = await inspectUpdateStatus(target)
+    const checked = await inspectUpdateStatus(target, entry)
     if (checked.updateState !== "available") {
       return {
         ok: false,

--- a/plugin/server/directory.ts
+++ b/plugin/server/directory.ts
@@ -6,7 +6,10 @@ import { promisify } from "node:util"
 import type { RpcInput, RpcOutput } from "@getpaseo/plugin"
 import * as semver from "semver"
 import { z } from "zod"
-import { getCatalogInstallArgs } from "../shared/catalog"
+import {
+  CATALOG_VERSION_MAX_LENGTH,
+  getCatalogInstallArgs,
+} from "../shared/catalog"
 import type {
   DirectoryEntry,
   directoryInstallRpc,
@@ -157,6 +160,10 @@ async function execGit(
 }
 
 type GitRunner = typeof execGit
+interface CatalogUpdateTarget {
+  ref?: string
+  version?: string
+}
 
 /**
  * Retains the Git safety checks for tracked sources, but only reports an
@@ -164,7 +171,7 @@ type GitRunner = typeof execGit
  */
 export async function inspectUpdateStatus(
   installation: InstalledPlugin,
-  entry: Pick<DirectoryEntry, "version">,
+  entry: CatalogUpdateTarget,
   runGit: GitRunner = execGit
 ): Promise<InstalledPlugin> {
   if (
@@ -199,6 +206,9 @@ export async function inspectUpdateStatus(
     }
     if (tracked.exitCode !== 0)
       throw new Error("Could not inspect tracked branch")
+    if (!entry.ref || installation.ref !== entry.ref) {
+      return { ...installation, updateState: "unknown" }
+    }
 
     const fetched = await runGit(
       installation.path,
@@ -260,9 +270,9 @@ export async function inspectUpdateStatus(
 
 async function cachedUpdateStatus(
   installation: InstalledPlugin,
-  entry: Pick<DirectoryEntry, "version">
+  entry: CatalogUpdateTarget
 ): Promise<InstalledPlugin> {
-  const key = `${installation.path}\u0000${installation.ref ?? ""}\u0000${installation.commit ?? ""}\u0000${installation.version ?? ""}\u0000${entry.version ?? ""}`
+  const key = `${installation.path}\u0000${installation.ref ?? ""}\u0000${installation.commit ?? ""}\u0000${installation.version ?? ""}\u0000${entry.ref ?? ""}\u0000${entry.version ?? ""}`
   const now = Date.now()
   const cached = updateStatusCache.get(key)
   if (cached && cached.expiresAt > now) return cached.value
@@ -305,12 +315,18 @@ async function addUpdateStatus(
 ): Promise<InstalledPlugin[]> {
   const matched = new Map<
     string,
-    { installation: InstalledPlugin; entry: DirectoryEntry }
+    { installation: InstalledPlugin; entry: CatalogUpdateTarget }
   >()
   for (const entry of plugins) {
     for (const installation of findInstallations(entry, installations)) {
       if (installation.source === "git") {
-        matched.set(installation.id, { installation, entry })
+        matched.set(installation.id, {
+          installation,
+          entry: {
+            ref: entry.repoMeta?.defaultBranch,
+            version: entry.version,
+          },
+        })
       }
     }
   }
@@ -356,8 +372,10 @@ export async function readInstalledPluginVersion(
     const contents = JSON.parse(
       await readFile(join(directory, "package.json"), "utf8")
     ) as { version?: unknown }
-    return typeof contents.version === "string"
-      ? (semver.valid(contents.version) ?? undefined)
+    if (typeof contents.version !== "string") return undefined
+    const version = semver.valid(contents.version) ?? undefined
+    return version && version.length <= CATALOG_VERSION_MAX_LENGTH
+      ? version
       : undefined
   } catch {
     return undefined
@@ -887,7 +905,10 @@ export async function updateDirectoryPlugin(
         message: `Installed plugin ${pluginId} does not match ${entry.repo}${entry.path ? `/${entry.path}` : ""}.`,
       }
     }
-    const checked = await inspectUpdateStatus(target, entry)
+    const checked = await inspectUpdateStatus(target, {
+      ref: entry.ref,
+      version: entry.version,
+    })
     if (checked.updateState !== "available") {
       return {
         ok: false,

--- a/plugin/shared/catalog.ts
+++ b/plugin/shared/catalog.ts
@@ -7,6 +7,8 @@
  * of React, the Paseo SDK, Zod, DOM globals, and Node APIs.
  */
 
+export const CATALOG_VERSION_MAX_LENGTH = 100
+
 export const CATALOG_PLATFORMS = ["macos", "linux", "windows"] as const
 
 export type CatalogPlatform = (typeof CATALOG_PLATFORMS)[number]

--- a/plugin/shared/directory.test.ts
+++ b/plugin/shared/directory.test.ts
@@ -34,6 +34,7 @@ const validEntry = {
   url: "https://github.com/owner/repo",
   name: "Plugin",
   description: "",
+  version: "1.2.3",
   categories: [],
   health: {},
   images: [],
@@ -121,6 +122,15 @@ describe("plugin install targets", () => {
       directoryEntrySchema.safeParse({ ...validEntry, repo: "paseo-cafe" })
         .success
     ).toBe(false)
+  })
+})
+
+describe("catalog version metadata", () => {
+  it("preserves versions while accepting legacy entries without one", () => {
+    expect(directoryEntrySchema.parse(validEntry).version).toBe("1.2.3")
+    expect(
+      directoryEntrySchema.parse({ ...validEntry, version: undefined }).version
+    ).toBeUndefined()
   })
 })
 

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -11,6 +11,7 @@ import {
   CATALOG_HEALTH_KEYS,
   CATALOG_HEALTH_LABELS,
   CATALOG_PLATFORM_LABELS,
+  CATALOG_VERSION_MAX_LENGTH,
   type CatalogCategory,
   type CatalogHealthCheck,
   getCatalogInstallCommand,
@@ -374,6 +375,9 @@ export const directoryEntrySchema = z.object({
   url: httpUrlSchema,
   name: z.string().max(200),
   description: z.string().max(4_000).default(""),
+  // Normalized package.json semver from the catalog scanner. Optional so an
+  // older catalog or a plugin without a valid version still remains browsable.
+  version: z.string().max(CATALOG_VERSION_MAX_LENGTH).optional(),
   author: z.string().max(200).optional(),
   categories: z.array(z.string().max(100)).max(32).default([]),
   platforms: z.array(z.string().max(100)).max(32).default([]),
@@ -468,6 +472,7 @@ export const installedPluginSchema = z.object({
   remote: z.string().optional(),
   ref: z.string().optional(),
   commit: z.string().optional(),
+  version: z.string().max(CATALOG_VERSION_MAX_LENGTH).optional(),
   latestCommit: z.string().optional(),
   updateState: z
     .enum(["unknown", "pinned", "current", "available", "diverged"])
@@ -601,6 +606,7 @@ export const directoryUpdateRpc = defineRpc({
       id: z.string(),
       repo: z.string(),
       path: z.string().optional(),
+      version: z.string().max(CATALOG_VERSION_MAX_LENGTH).optional(),
     }),
   }),
   output: z.object({

--- a/plugin/shared/directory.ts
+++ b/plugin/shared/directory.ts
@@ -606,6 +606,11 @@ export const directoryUpdateRpc = defineRpc({
       id: z.string(),
       repo: z.string(),
       path: z.string().optional(),
+      ref: z
+        .string()
+        .max(255)
+        .refine(isValidCatalogRef, "Expected a valid Git branch")
+        .optional(),
       version: z.string().max(CATALOG_VERSION_MAX_LENGTH).optional(),
     }),
   }),

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -313,17 +313,20 @@ describe("scanOne", () => {
     }
   )
 
-  it("flags a placeholder package version", async () => {
-    const registryRoot = exampleRegistry()
-    mockRepository(Response.json({ sha: REVISION }), "0.0.0")
+  it.each(["0.0.0", "v0.0.0", "0.0.0+build.1"])(
+    "flags a normalized placeholder package version (%s)",
+    async (packageVersion) => {
+      const registryRoot = exampleRegistry()
+      mockRepository(Response.json({ sha: REVISION }), packageVersion)
 
-    const record = await scanOne("example.json", {}, registryRoot)
+      const record = await scanOne("example.json", {}, registryRoot)
 
-    expect(record.version).toBe("0.0.0")
-    expect(record.scanError).toBe(
-      'package.json version "0.0.0" is a placeholder; publish a real release version'
-    )
-  })
+      expect(record.version).toBe("0.0.0")
+      expect(record.scanError).toBe(
+        'package.json version "0.0.0" is a placeholder; publish a real release version'
+      )
+    }
+  )
 
   it("publishes a generic scan error without upstream response details", async () => {
     const registryRoot = exampleRegistry()

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -313,6 +313,18 @@ describe("scanOne", () => {
     }
   )
 
+  it("flags a placeholder package version", async () => {
+    const registryRoot = exampleRegistry()
+    mockRepository(Response.json({ sha: REVISION }), "0.0.0")
+
+    const record = await scanOne("example.json", {}, registryRoot)
+
+    expect(record.version).toBe("0.0.0")
+    expect(record.scanError).toBe(
+      'package.json version "0.0.0" is a placeholder; publish a real release version'
+    )
+  })
+
   it("publishes a generic scan error without upstream response details", async () => {
     const registryRoot = exampleRegistry()
     vi.spyOn(console, "warn").mockImplementation(() => undefined)

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -175,7 +175,10 @@ function exampleRegistry(): string {
   return registryRoot
 }
 
-function mockRepository(commitResponse: Response): void {
+function mockRepository(
+  commitResponse: Response,
+  packageVersion: unknown
+): void {
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input)
     if (url === "https://api.github.com/repos/acme/widgets") {
@@ -246,7 +249,7 @@ function mockRepository(commitResponse: Response): void {
     if (url.endsWith("/plugin/package.json")) {
       return Response.json({
         description: "Package description",
-        version: "1.2.3",
+        version: packageVersion,
         scripts: { test: "vitest" },
       })
     }
@@ -262,7 +265,7 @@ function mockRepository(commitResponse: Response): void {
 describe("scanOne", () => {
   it("keeps branch metadata without attaching security when commit resolution fails", async () => {
     const registryRoot = exampleRegistry()
-    mockRepository(new Response("temporary outage", { status: 503 }))
+    mockRepository(new Response("temporary outage", { status: 503 }), "1.2.3")
 
     const record = await scanOne(
       "example.json",
@@ -279,6 +282,7 @@ describe("scanOne", () => {
     )
 
     expect(record.description).toBe("Package description")
+    expect(record.version).toBe("1.2.3")
     expect(record.health).toMatchObject({
       manifestValid: true,
       hasReadme: true,
@@ -295,6 +299,19 @@ describe("scanOne", () => {
     expect(record.scanError).toContain("default branch commit unavailable")
     expect(record.scanError).not.toContain("temporary outage")
   })
+
+  it.each([undefined, "not-semver"])(
+    "omits a missing or invalid package version (%s)",
+    async (packageVersion) => {
+      const registryRoot = exampleRegistry()
+      mockRepository(Response.json({ sha: REVISION }), packageVersion)
+
+      const record = await scanOne("example.json", {}, registryRoot)
+
+      expect(record.version).toBeUndefined()
+      expect(record.scanError).toBeUndefined()
+    }
+  )
 
   it("publishes a generic scan error without upstream response details", async () => {
     const registryRoot = exampleRegistry()
@@ -314,7 +331,7 @@ describe("scanOne", () => {
 
   it("uses the default branch for human links and the commit for attestations and raw assets", async () => {
     const registryRoot = exampleRegistry()
-    mockRepository(Response.json({ sha: REVISION }))
+    mockRepository(Response.json({ sha: REVISION }), "1.2.3")
 
     const security: PluginSecurity = {
       status: "passed",

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -382,6 +382,12 @@ export async function scanOne(
         `paseo-plugin.json id "${manifestId}" must match registry ID "${id}"`
       )
     }
+    if (pkg?.version === "0.0.0") {
+      scanErrors.push(
+        'package.json version "0.0.0" is a placeholder; publish a real release version'
+      )
+    }
+
     if (scanErrors.length > 0) record.scanError = scanErrors.join("; ")
 
     return pluginRecordSchema.parse(record)

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -382,7 +382,7 @@ export async function scanOne(
         `paseo-plugin.json id "${manifestId}" must match registry ID "${id}"`
       )
     }
-    if (pkg?.version === "0.0.0") {
+    if (version === "0.0.0") {
       scanErrors.push(
         'package.json version "0.0.0" is a placeholder; publish a real release version'
       )

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -31,6 +31,7 @@ import { renderMarkdownToHtml } from "../src/lib/markdown.ts"
 import type { PluginRecord, PluginSecurity } from "../src/lib/plugin-schema.ts"
 import {
   gitCommitSchema,
+  normalizePluginVersion,
   pluginOwnerLogin,
   pluginRecordSchema,
   pluginSecuritySchema,
@@ -314,6 +315,7 @@ export async function scanOne(
       0,
       MAX_README_IMAGES
     )
+    const version = normalizePluginVersion(pkg?.version)
 
     const record: PluginRecord = {
       id,
@@ -326,7 +328,7 @@ export async function scanOne(
         manifestDescription ??
         firstParagraph(readme ?? "") ??
         "",
-      version: pkg?.version,
+      version,
       author: authorName(pkg?.author),
       license: repoMeta.license?.spdx_id ?? pkg?.license,
       categories: entry.categories,

--- a/src/lib/directory-api.ts
+++ b/src/lib/directory-api.ts
@@ -1,7 +1,12 @@
 import { z } from "zod"
 import { isTrustedRemoteImageUrl } from "@/lib/images"
-import { type PluginRecord, pluginHealthSchema } from "@/lib/plugin-schema"
+import {
+  normalizePluginVersion,
+  type PluginRecord,
+  pluginHealthSchema,
+} from "@/lib/plugin-schema"
 import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/lib/site"
+import { CATALOG_VERSION_MAX_LENGTH } from "../../plugin/shared/catalog"
 
 export const MAX_API_RESPONSE_BYTES = 16 * 1_024 * 1_024
 export const MAX_API_README_TEXT_LENGTH = 16_000
@@ -26,6 +31,7 @@ export const directoryPluginSchema = z.object({
   url: httpUrlSchema.max(2_048),
   name: z.string().max(200),
   description: z.string().max(1_000),
+  version: z.string().max(CATALOG_VERSION_MAX_LENGTH).optional(),
   author: z.string().max(200).optional(),
   license: z.string().max(100).optional(),
   paseoVersionRequirement: z.string().max(200).optional(),
@@ -104,6 +110,7 @@ export function projectPluginForDirectory(
       `Plugin ${plugin.id.slice(0, 200)} has overlong identity data`
     )
   }
+  const version = normalizePluginVersion(plugin.version)
 
   const security =
     plugin.security?.status === "unknown" || !plugin.security
@@ -133,6 +140,7 @@ export function projectPluginForDirectory(
     health: plugin.health,
     scannedAt: boundedString(plugin.scannedAt, 100),
     ...(plugin.path ? { path: plugin.path } : {}),
+    ...(version !== undefined ? { version } : {}),
     ...(security ? { security } : {}),
     ...(plugin.scanError
       ? { scanError: boundedString(plugin.scanError, 4_000) }

--- a/src/lib/plugin-schema.test.ts
+++ b/src/lib/plugin-schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { pluginRecordSchema, pluginSecuritySchema } from "./plugin-schema"
+import {
+  normalizePluginVersion,
+  pluginRecordSchema,
+  pluginSecuritySchema,
+} from "./plugin-schema"
 
 const validHealth = {
   manifestValid: true,
@@ -32,6 +36,14 @@ const validRecordBase = {
   images: [],
   scannedAt: new Date().toISOString(),
 }
+
+describe("normalizePluginVersion", () => {
+  it("normalizes valid semver and omits invalid versions", () => {
+    expect(normalizePluginVersion("v1.2.3-beta.1+build.4")).toBe("1.2.3-beta.1")
+    expect(normalizePluginVersion("1.2")).toBeUndefined()
+    expect(normalizePluginVersion(undefined)).toBeUndefined()
+  })
+})
 
 describe("pluginRecordSchema", () => {
   it("accepts a fully-populated scanned record", () => {

--- a/src/lib/plugin-schema.test.ts
+++ b/src/lib/plugin-schema.test.ts
@@ -43,6 +43,11 @@ describe("normalizePluginVersion", () => {
     expect(normalizePluginVersion("1.2")).toBeUndefined()
     expect(normalizePluginVersion(undefined)).toBeUndefined()
   })
+
+  it("omits normalized versions beyond the catalog length limit", () => {
+    expect(normalizePluginVersion(`1.0.0-${"a".repeat(94)}`)).toHaveLength(100)
+    expect(normalizePluginVersion(`1.0.0-${"a".repeat(95)}`)).toBeUndefined()
+  })
 })
 
 describe("pluginRecordSchema", () => {

--- a/src/lib/plugin-schema.ts
+++ b/src/lib/plugin-schema.ts
@@ -38,7 +38,10 @@ export const gitCommitSchema = z
 
 export function normalizePluginVersion(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined
-  return semver.valid(value) ?? undefined
+  const normalized = semver.valid(value) ?? undefined
+  return normalized && normalized.length <= CATALOG_VERSION_MAX_LENGTH
+    ? normalized
+    : undefined
 }
 
 export const pluginSecuritySchema = z

--- a/src/lib/plugin-schema.ts
+++ b/src/lib/plugin-schema.ts
@@ -1,6 +1,10 @@
+import * as semver from "semver"
 import { z } from "zod"
 import { PLATFORMS } from "@/lib/registry-schema"
-import type { CatalogHealthCheck } from "../../plugin/shared/catalog"
+import {
+  CATALOG_VERSION_MAX_LENGTH,
+  type CatalogHealthCheck,
+} from "../../plugin/shared/catalog"
 
 /**
  * The enriched, generated record for one plugin. Never hand-authored — the
@@ -31,6 +35,11 @@ export const gitCommitSchema = z
   .trim()
   .regex(/^[0-9a-f]{40}$/i, "Must be a full Git commit SHA")
   .transform((commit) => commit.toLowerCase())
+
+export function normalizePluginVersion(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  return semver.valid(value) ?? undefined
+}
 
 export const pluginSecuritySchema = z
   .object({
@@ -103,7 +112,7 @@ export const pluginRecordSchema = z.object({
   url: z.string().url(),
   name: z.string(),
   description: z.string().default(""),
-  version: z.string().optional(),
+  version: z.string().max(CATALOG_VERSION_MAX_LENGTH).optional(),
   author: z.string().optional(),
   license: z.string().optional(),
   categories: z.array(z.string()).default([]),

--- a/src/routes/-api.plugins.test.ts
+++ b/src/routes/-api.plugins.test.ts
@@ -52,6 +52,7 @@ describe("GET /api/plugins", () => {
       url: "https://github.com/example/adversarial",
       name: "Adversarial",
       description: "",
+      version: "1.2.3",
       manifest: { payload: "m".repeat(100_000) },
       categories: [],
       platforms: [],
@@ -93,6 +94,7 @@ describe("GET /api/plugins", () => {
     expect(projected).not.toHaveProperty("readmeHtml")
     expect(projected).not.toHaveProperty("security")
     expect(directoryPluginSchema.safeParse(projected).success).toBe(true)
+    expect(projected.version).toBe("1.2.3")
     expect(projected.readmeText).toBe(
       readmeText.slice(0, MAX_API_README_TEXT_LENGTH)
     )

--- a/src/routes/submit.tsx
+++ b/src/routes/submit.tsx
@@ -80,6 +80,7 @@ const FIELDS: { field: string; required: boolean; description: string }[] = [
 const REQUIRED_CHECKS = [
   "Your repo is public on GitHub.",
   "Its paseo-plugin.json id matches the registry filename.",
+  "Its package.json has a released semantic version, not 0.0.0, and you will increment it for each plugin update.",
 ]
 
 const RECOMMENDED = [
@@ -93,7 +94,8 @@ const RECOMMENDED = [
 ]
 
 const AUTO_GENERATED = [
-  "Name from the validated plugin ID; description, version, author, and license from package.json, paseo-plugin.json, and the README.",
+  "Name from the validated plugin ID; description, author, and license from package.json, paseo-plugin.json, and the README. package.json.version is the update identity used by the companion catalog.",
+
   "The exact install command (paseo plugin add ...), derived from repo + path.",
   "Screenshots, from an images/ folder in your repo.",
   "Demo videos, detected in your README (YouTube, Loom, or an uploaded GitHub video).",


### PR DESCRIPTION
## Problem

Paseo Cafe currently treats any tracked-branch commit as a plugin update. In monorepos, an unrelated root README or sibling-plugin change therefore marks every installed plugin from that repository as outdated.

## Change

- Read and normalize each plugin's `package.json.version` during catalog scanning.
- Expose the optional validated version through the directory API and companion contract.
- Read the installed plugin's own `package.json`, including monorepo subpaths.
- Report an available update only when both versions are valid semver values and the catalog version is greater.
- Keep commit ancestry checks for pinned/diverged-source safety.
- Report missing or invalid version metadata as unknown instead of falling back to repository-HEAD movement.
- Recheck update eligibility before invoking the existing Paseo update command.
- Bound normalized versions to the catalog contract so unusually long but syntactically valid values are omitted rather than failing the plugin scan.

Git remains the transport. This PR intentionally does not change the commit selected by Paseo's install/update command; exact catalog-version-to-commit installation requires the separate Paseo core `plugin update --ref` capability.

## Registry readiness analysis

Audited all 58 registry entries against the current `package.json` at each configured repository and monorepo subpath:

- 58/58 package files present.
- 58/58 declare syntactically valid semver.
- No missing or malformed versions.
- 15 entries use the placeholder version `0.0.0`:
  - `obol`
  - `archive-branch-cleanup`
  - `colorful-agent-activity`
  - `opencode-session-overview`
  - `pi-plugin-mcowger`
  - `pi-tasks-timeline`
  - `reasoning-display`
  - `session-summary`
  - `subagent-activity`
  - `paseo-display-switcher`
  - `catppuccin-theme`
  - `discord-rich-presence`
  - `setup-monitor`
  - `time-since`
  - `workspace-links`

`0.0.0` is valid semver, but those plugins will remain `current` across repository changes until their maintainers begin incrementing the package version. The remaining 43 entries already provide usable update identities. Valid prerelease versions, including `0.1.0-rc.3`, follow normal semver precedence.

The unauthenticated local full-registry scan hit GitHub API rate limits after 17 entries; the audit was completed using authenticated GitHub file reads. CI must continue supplying its GitHub token for complete enrichment.

## Verification

- CI passed on the initial feature commit across app and Linux/macOS/Windows plugin jobs.
- Review regression: normalized versions of 100 characters are accepted; 101-character values are omitted.
- Website scanner/schema/API tests pass: 31 focused tests.
- Companion update tests pass: 36 focused tests.
- Website typecheck and formatting pass for changed files.
- Root `bun run check` remains blocked only by the pre-existing `.release-please-manifest.json` formatting defect.
- Agent-reported full feature validation: 191 website tests, website production build, 88 companion tests, companion typecheck, scoped Biome checks, and a temporary runtime plugin-install smoke test.

## Not included

- Recently-added/updated sorting changes from #85.
- npm-registry plugin installation.
- Exact catalog-version-to-commit installation; tracked separately in Paseo core.
- Any plugin version bump; release-please remains responsible for releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plugin catalog entries now display normalized semantic versions.
  - Updates are offered only when a newer valid version is available on the matching branch.
  - Missing or invalid versions show update status as unavailable.
  - Plugin update requests now preserve version and branch information.

- **Bug Fixes**
  - Unrelated repository commits no longer incorrectly mark plugins as outdated.
  - Placeholder versions such as `0.0.0` are flagged during scanning.

- **Documentation**
  - Added guidance for plugin versioning, submissions, updates, and known installation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->