### PR TITLE
add remote-editor plugin

### DIFF
--- a/registry/remote-editor.json
+++ b/registry/remote-editor.json
@@ -1,7 +1,6 @@
 {
   "repo": "alhassanaraouf/paseo-remote-editor",
   "categories": ["productivity"],
-  "platforms": ["macos", "linux", "windows"],
   "caveats": [
     "Requires the SSH-based remote-development extension for the chosen editor already set up on your machine",
     "Not shown on iOS or Android"

--- a/registry/remote-editor.json
+++ b/registry/remote-editor.json
@@ -1,0 +1,10 @@
+{
+  "repo": "alhassanaraouf/paseo-remote-editor",
+  "categories": ["productivity"],
+  "platforms": ["macos", "linux", "windows"],
+  "caveats": [
+    "Requires the SSH-based remote-development extension for the chosen editor already set up on your machine",
+    "Not shown on iOS or Android"
+  ],
+  "submittedBy": "alhassanaraouf"
+}


### PR DESCRIPTION
## Summary
- Adds `registry/remote-editor.json` for [alhassanaraouf/paseo-remote-editor](https://github.com/alhassanaraouf/paseo-remote-editor).
- Composer pill that opens an agent's workspace over SSH in VS Code, Cursor, or Zed on the daemon machine; includes a settings screen for the default editor and custom editor URI templates. Desktop only.

## Test plan
- [x] Filename matches `paseo-plugin.json`'s `id` (`remote-editor`)
- [x] `paseo-plugin.json`, `README.md`, and `LICENSE` present in the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a registry listing for Paseo Remote Editor.
  - The listing identifies it as a productivity tool with support for macOS, Linux, and Windows.
  - Included compatibility notes: an SSH-based remote-development extension is required, and the listing is unavailable on iOS and Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->