### PR TITLE
feat(dev): add bun run dev:light for fast local scans

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run registry:ensure && vite dev --port 3000",
+    "dev:light": "bun run scripts/scan.ts --if-missing --limit 20 && vite dev --port 3000",
     "build": "bun run registry:ensure && bun run build:generated",
     "preview": "vite preview",
     "test": "bun run registry:ensure && vitest run",

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -274,7 +274,7 @@ function mockRepository(
 }
 
 describe("isFullyScanned", () => {
-  it("requires a valid successful cached record and its OG image", async () => {
+  it("requires a valid cached record for the right id, plus its OG image", async () => {
     const registryRoot = exampleRegistry()
     const cacheRoot = temporaryDirectory()
     const outputDir = join(cacheRoot, "data")
@@ -291,9 +291,21 @@ describe("isFullyScanned", () => {
 
     expect(isFullyScanned("example.json", outputDir, ogDir)).toBe(true)
 
+    // A scanError is a persistent catalog problem (bad manifest, placeholder
+    // version), not a sign the cache entry is incomplete — --if-missing must
+    // not keep retrying it every run, so it still counts as fully scanned.
     writeFileSync(
       join(outputDir, "example.json"),
-      JSON.stringify({ ...record, scanError: "temporary failure" })
+      JSON.stringify({
+        ...record,
+        scanError: "package.json version is a placeholder",
+      })
+    )
+    expect(isFullyScanned("example.json", outputDir, ogDir)).toBe(true)
+
+    writeFileSync(
+      join(outputDir, "example.json"),
+      JSON.stringify({ ...record, id: "someone-else" })
     )
     expect(isFullyScanned("example.json", outputDir, ogDir)).toBe(false)
 

--- a/scripts/scan.test.ts
+++ b/scripts/scan.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { PluginSecurity } from "../src/lib/plugin-schema"
 import {
+  isFullyScanned,
   loadPublishedSecurityCatalog,
   readRegistryAddedAt,
   renderPluginsRedirect,
@@ -271,6 +272,35 @@ function mockRepository(
     throw new Error(`unexpected request: ${url}`)
   }) as typeof fetch
 }
+
+describe("isFullyScanned", () => {
+  it("requires a valid successful cached record and its OG image", async () => {
+    const registryRoot = exampleRegistry()
+    const cacheRoot = temporaryDirectory()
+    const outputDir = join(cacheRoot, "data")
+    const ogDir = join(cacheRoot, "og")
+    mkdirSync(outputDir)
+    mkdirSync(ogDir)
+    mockRepository(Response.json({ sha: REVISION }), "1.2.3")
+
+    expect(isFullyScanned("example.json", outputDir, ogDir)).toBe(false)
+
+    const record = await scanOne("example.json", {}, registryRoot)
+    writeFileSync(join(outputDir, "example.json"), JSON.stringify(record))
+    writeFileSync(join(ogDir, "example.png"), "png")
+
+    expect(isFullyScanned("example.json", outputDir, ogDir)).toBe(true)
+
+    writeFileSync(
+      join(outputDir, "example.json"),
+      JSON.stringify({ ...record, scanError: "temporary failure" })
+    )
+    expect(isFullyScanned("example.json", outputDir, ogDir)).toBe(false)
+
+    writeFileSync(join(outputDir, "example.json"), "not json")
+    expect(isFullyScanned("example.json", outputDir, ogDir)).toBe(false)
+  })
+})
 
 describe("renderPluginsRedirect", () => {
   afterEach(() => {

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -598,7 +598,14 @@ export function renderRobotsTxt(): string {
   return `User-agent: *\nAllow: /\n\nSitemap: ${SITE_URL}/sitemap.xml\n`
 }
 
-/** True once a plugin has a valid, successful cached record and OG image. */
+/**
+ * True once a plugin has a valid cached record and OG image. Deliberately
+ * does not require `scanError` to be unset: a scanError can be a persistent
+ * catalog problem (mismatched manifest ID, placeholder version) rather than
+ * a transient failure, and treating every scanError as "incomplete" would
+ * make `--if-missing --limit N` retry the same broken entry every run,
+ * burning the limit and starving entries that have never been scanned.
+ */
 export function isFullyScanned(
   file: string,
   outputDir = OUTPUT_DIR,
@@ -608,7 +615,7 @@ export function isFullyScanned(
   const record = readCachedRecord(id, outputDir)
   return (
     record !== undefined &&
-    record.scanError === undefined &&
+    record.id === id &&
     existsSync(join(ogDir, `${id}.png`))
   )
 }

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -11,6 +11,9 @@
  * its record is written with `scanError` set and health flags at their
  * safest defaults, so the listing can surface it as "needs attention"
  * instead of the whole build breaking.
+ *
+ * `--limit N` caps how many entries a run scans (see parseLimitArg) — used
+ * by `bun run dev:light` so local dev doesn't wait on the whole registry.
  */
 import { execFileSync } from "node:child_process"
 import {
@@ -595,6 +598,49 @@ export function renderRobotsTxt(): string {
   return `User-agent: *\nAllow: /\n\nSitemap: ${SITE_URL}/sitemap.xml\n`
 }
 
+/** True once both a plugin's data record and OG image are on disk from a previous scan. */
+function isFullyScanned(file: string): boolean {
+  const id = file.slice(0, -".json".length)
+  return (
+    existsSync(join(OUTPUT_DIR, `${id}.json`)) &&
+    existsSync(join(OG_DIR, `${id}.png`))
+  )
+}
+
+/**
+ * Loads a plugin's previously written data/plugins/<id>.json so it can be
+ * folded into the aggregate index without rescanning it — used when a run
+ * only covers part of the registry (see --limit).
+ */
+function readCachedRecord(id: string): PluginRecord | undefined {
+  const path = join(OUTPUT_DIR, `${id}.json`)
+  if (!existsSync(path)) return undefined
+  try {
+    return pluginRecordSchema.parse(JSON.parse(readFileSync(path, "utf8")))
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * `--limit N`: cap how many registry entries this run scans, for a fast
+ * local `bun run dev:light` on a registry with hundreds of entries. Combined
+ * with --if-missing, repeated light runs scan a fresh N entries each time
+ * (in filename order) until the whole registry is warm, without ever paying
+ * for a full scan up front. The aggregate index/sitemap only ever list
+ * entries that have actually been scanned at least once.
+ */
+function parseLimitArg(): number | undefined {
+  const flagIndex = process.argv.indexOf("--limit")
+  if (flagIndex === -1) return undefined
+  const raw = process.argv[flagIndex + 1]
+  const value = raw ? Number(raw) : Number.NaN
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error("--limit requires a positive integer, e.g. --limit 20")
+  }
+  return value
+}
+
 async function main() {
   if (process.argv.includes("--deployment-files-only")) {
     const records = pluginRecordSchema
@@ -605,24 +651,33 @@ async function main() {
     return
   }
 
-  const files = readdirSync(REGISTRY_DIR).filter((file) =>
-    file.endsWith(".json")
-  )
-  const outputExists =
+  const files = readdirSync(REGISTRY_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+  const useIfMissing = process.argv.includes("--if-missing")
+  const limit = parseLimitArg()
+
+  let filesToScan = useIfMissing
+    ? files.filter((file) => !isFullyScanned(file))
+    : files
+  if (limit !== undefined) filesToScan = filesToScan.slice(0, limit)
+
+  const staticFilesReady =
     existsSync(INDEX_PATH) &&
     existsSync(join(PUBLIC_DIR, "sitemap.xml")) &&
     existsSync(join(PUBLIC_DIR, "robots.txt")) &&
     existsSync(join(PUBLIC_DIR, "plugins", "index.html")) &&
-    existsSync(join(OG_DIR, "default.png")) &&
-    files.every((file) => {
-      const id = file.slice(0, -".json".length)
-      return (
-        existsSync(join(OUTPUT_DIR, `${id}.json`)) &&
-        existsSync(join(OG_DIR, `${id}.png`))
-      )
-    })
+    existsSync(join(OG_DIR, "default.png"))
 
-  if (process.argv.includes("--if-missing") && outputExists) return
+  if (
+    useIfMissing &&
+    limit === undefined &&
+    filesToScan.length === 0 &&
+    staticFilesReady
+  ) {
+    return
+  }
+
   mkdirSync(OUTPUT_DIR, { recursive: true })
   mkdirSync(OG_DIR, { recursive: true })
 
@@ -635,8 +690,8 @@ async function main() {
   }
   const offline = process.argv.includes("--offline")
 
-  const records: PluginRecord[] = []
-  for (const file of files) {
+  const scanned = new Map<string, PluginRecord>()
+  for (const file of filesToScan) {
     console.log(`Scanning ${file}...`)
     const record = await scanOne(
       file,
@@ -646,7 +701,7 @@ async function main() {
       offline
     )
     if (record.scanError) console.warn(`  ! ${record.scanError}`)
-    records.push(record)
+    scanned.set(record.id, record)
     writeFileSync(
       join(OUTPUT_DIR, `${record.id}.json`),
       `${JSON.stringify(record, null, 2)}\n`
@@ -662,6 +717,15 @@ async function main() {
     })
   }
 
+  // The aggregate index covers everything scanned in this run plus anything
+  // already cached from a prior run; a registry entry that's never been
+  // scanned yet is simply left out (that's the point of --limit).
+  const records = files
+    .map((file) => {
+      const id = file.slice(0, -".json".length)
+      return scanned.get(id) ?? readCachedRecord(id)
+    })
+    .filter((record): record is PluginRecord => record !== undefined)
   records.sort((a, b) => a.name.localeCompare(b.name))
   writeFileSync(INDEX_PATH, `${JSON.stringify(records, null, 2)}\n`)
 
@@ -673,11 +737,15 @@ async function main() {
   writePluginsRedirect()
 
   const ok = records.filter((r) => !r.scanError).length
+  const coverage =
+    records.length < files.length
+      ? ` (${files.length - records.length} of ${files.length} registry entries not yet scanned — run \`bun run registry:scan\` for the full catalog)`
+      : ""
   console.log(
-    `\nWrote ${records.length} record(s) (${ok} clean, ${records.length - ok} with warnings) to data/plugins.json`
+    `\nWrote ${records.length} record(s) (${ok} clean, ${records.length - ok} with warnings) to data/plugins.json${coverage}`
   )
   console.log(
-    `Wrote ${records.length + 1} OG image(s), sitemap.xml, robots.txt, and plugins/index.html to public/`
+    `Wrote ${scanned.size} OG image(s) this run, plus sitemap.xml, robots.txt, and plugins/index.html to public/`
   )
 }
 

--- a/scripts/scan.ts
+++ b/scripts/scan.ts
@@ -598,12 +598,18 @@ export function renderRobotsTxt(): string {
   return `User-agent: *\nAllow: /\n\nSitemap: ${SITE_URL}/sitemap.xml\n`
 }
 
-/** True once both a plugin's data record and OG image are on disk from a previous scan. */
-function isFullyScanned(file: string): boolean {
+/** True once a plugin has a valid, successful cached record and OG image. */
+export function isFullyScanned(
+  file: string,
+  outputDir = OUTPUT_DIR,
+  ogDir = OG_DIR
+): boolean {
   const id = file.slice(0, -".json".length)
+  const record = readCachedRecord(id, outputDir)
   return (
-    existsSync(join(OUTPUT_DIR, `${id}.json`)) &&
-    existsSync(join(OG_DIR, `${id}.png`))
+    record !== undefined &&
+    record.scanError === undefined &&
+    existsSync(join(ogDir, `${id}.png`))
   )
 }
 
@@ -612,8 +618,11 @@ function isFullyScanned(file: string): boolean {
  * folded into the aggregate index without rescanning it — used when a run
  * only covers part of the registry (see --limit).
  */
-function readCachedRecord(id: string): PluginRecord | undefined {
-  const path = join(OUTPUT_DIR, `${id}.json`)
+function readCachedRecord(
+  id: string,
+  outputDir = OUTPUT_DIR
+): PluginRecord | undefined {
+  const path = join(outputDir, `${id}.json`)
   if (!existsSync(path)) return undefined
   try {
     return pluginRecordSchema.parse(JSON.parse(readFileSync(path, "utf8")))

--- a/src/components/plugin-install-section.tsx
+++ b/src/components/plugin-install-section.tsx
@@ -24,7 +24,7 @@ export function PluginInstallSection({ plugin }: { plugin: PluginRecord }) {
               before it's ever written to data/plugins.json — never render
               raw third-party markdown here. */}
           <div
-            className="prose prose-sm dark:prose-invert max-w-none prose-pre:rounded-none prose-pre:bg-muted font-mono text-foreground/70"
+            className="prose prose-sm dark:prose-invert max-w-none prose-pre:rounded-none prose-pre:bg-muted font-mono prose-pre:text-foreground text-foreground/70"
             /* biome-ignore lint/security/noDangerouslySetInnerHtml: The scan pipeline sanitizes this HTML with rehype-sanitize. */
             dangerouslySetInnerHTML={{ __html: plugin.installNotesHtml }}
           />

--- a/src/components/plugin-readme.tsx
+++ b/src/components/plugin-readme.tsx
@@ -7,7 +7,7 @@ export function PluginReadme({ html }: { html: string }) {
         README
       </p>
       <div
-        className="prose prose-sm dark:prose-invert max-w-none prose-pre:rounded-none prose-pre:bg-muted"
+        className="prose prose-sm dark:prose-invert max-w-none prose-pre:rounded-none prose-pre:bg-muted prose-pre:text-foreground"
         /* biome-ignore lint/security/noDangerouslySetInnerHtml: The scan pipeline sanitizes this HTML; legacy image tags and relative links are removed again here. */
         dangerouslySetInnerHTML={{
           __html: sanitizeReadmeHtmlForDisplay(html),


### PR DESCRIPTION
## Why

Scanning the full plugin registry on every `bun dev` spin-up doesn't scale — as the registry grows into the hundreds of entries, cold-start local dev will take forever.

## What

- Adds `bun run dev:light`: scans only the first 20 uncached registry entries via a new `--limit N` flag on `scripts/scan.ts`, then starts `vite dev`. Regular `bun dev` / `build` / `test` are unaffected — they don't pass `--limit`, so they still scan the whole registry as before.
- Fixes `--if-missing` to check per-entry instead of all-or-nothing: it used to rescan the *entire* registry if even one plugin's output was missing (e.g. after adding a single new entry). Now it only (re)scans what's actually missing, so repeated `dev:light` runs incrementally warm the cache rather than rescanning the same entries every time.
- Small style fix: `prose-pre:text-foreground` on the plugin install/readme code blocks.

## Validation

```bash
bun run check
bunx tsc --noEmit
bunx vitest run scripts/scan.test.ts
```

Also smoke-tested `--limit` in a scratch checkout: first run scanned 5 entries, second run correctly skipped those and scanned the next 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a lightweight development mode that performs a limited scan before starting the app.
  - Scans can now limit the number of registry entries processed in one run.

- **Bug Fixes**
  - Scan completion now requires valid, error-free cached data and a generated preview image, preventing incomplete results from being treated as fully scanned.

- **Style**
  - Improved readability of code blocks in plugin installation notes and rendered README content by applying the standard foreground text color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->