### PR TITLE
Migrate Activity and DeepSeek Harness to paseo-stuff

### DIFF
--- a/registry/deepseek-harness.json
+++ b/registry/deepseek-harness.json
@@ -1,5 +1,6 @@
 {
-  "repo": "geoqiao/paseo-deepseek-harness",
+  "repo": "geoqiao/paseo-stuff",
+  "path": "plugins/deepseek-harness",
   "categories": ["provider"],
   "caveats": [
     "Experimental: requires Paseo 0.8, daemon Node >=22.19, and a separately installed official DSH with credentials.",

--- a/registry/readable-agent-activity.json
+++ b/registry/readable-agent-activity.json
@@ -1,5 +1,6 @@
 {
-  "repo": "geoqiao/paseo-readable-activity",
+  "repo": "geoqiao/paseo-stuff",
+  "path": "plugins/agent-activity",
   "categories": ["productivity"],
   "caveats": [
     "Experimental beta: verified on Paseo 0.8.0, Full detail only; Summary is unsupported.",


### PR DESCRIPTION
## Scope
Update the two existing entries originally accepted in #86 and #87, without deleting/re-adding them or changing plugin IDs, categories, caveats or attribution:
- readable-agent-activity → geoqiao/paseo-stuff, path plugins/agent-activity
- deepseek-harness → geoqiao/paseo-stuff, path plugins/deepseek-harness

Only the two registry pointer files change. The public monorepo is ready and has per-plugin manifests, npm lockfiles, licenses, provenance, tests and immutable release tags. Activity beta.5 includes a tested native bundle-loading fix; DSH beta.3 is metadata-only over beta.2. New releases: https://github.com/geoqiao/paseo-stuff/releases

Old repositories and tags are retained with migration notices. Existing Git installs do not change sources automatically; downtime, settings removal and enabled-state caveats are documented at https://github.com/geoqiao/paseo-stuff/blob/main/MIGRATION.md . No installed source is changed by this PR.

## Validation
- Live GitHub repo/subpath/manifest-ID validation passed for both migrated pointers (and the separate Math Renderer submission).
- Offline registry validation: 63 entries passed; check:app, website typecheck, canonical build passed.
- Companion plugin typecheck and all 104 tests passed.
- Monorepo Node 22/24 CI: all eight jobs passed. Activity: 250 tests plus one explicit Hermes skip on Linux; all 251 passed locally with real Hermes. DSH: 32 tests.
- Full Cafe check is blocked by existing .release-please-manifest.json formatting. Website tests: 214 pass, one static-scan test fails on this local macOS environment (missing root-dependency finding). Both failures reproduce on unmodified upstream main b9edc16, independent of registry changes. No unrelated fixes included.
- The repository-requested bd CLI is unavailable locally.

Please update the existing catalog entries rather than create duplicate listings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated plugin registry entries for DeepSeek Harness and Readable Agent Activity.
  - Both plugins now resolve through the consolidated repository structure, improving installation and discovery through the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->