### PR TITLE
Add Math Renderer plugin (block-math beta)

### DIFF
--- a/registry/math-renderer.json
+++ b/registry/math-renderer.json
@@ -1,0 +1,14 @@
+{
+  "repo": "geoqiao/paseo-stuff",
+  "path": "plugins/math-renderer",
+  "categories": ["productivity"],
+  "caveats": [
+    "Experimental beta for Paseo app and daemon 0.8.0 only; block math only, not inline math.",
+    "macOS desktop checked; native iOS/Android and sustained multi-client load are untested.",
+    "Unsupported Markdown source rows stay native; code highlighting and native file interactions are not fully reproduced.",
+    "Missing glyphs, custom macros, unsupported commands and oversized formulas fall back to source.",
+    "Uses local MathJax and embedded resvg WASM; input bounds are not a hard CPU or memory sandbox.",
+    "Avoid enabling another assistant-message replacement plugin for the same content."
+  ],
+  "submittedBy": "geoqiao"
+}


### PR DESCRIPTION
## Plugin
Add one new registry pointer: geoqiao/paseo-stuff, path plugins/math-renderer, ID math-renderer.

Math Renderer beta.1 renders block LaTeX amid Markdown prose, with a single muted English Show/Copy row and source fallback. It uses local MathJax and embedded resvg WASM, without a browser/WebView or runtime network calls. The repository contains independent npm metadata and build instructions, MIT and third-party notices, exact host-fixture provenance, tests and clearly labeled synthetic screenshots.

Release: https://github.com/geoqiao/paseo-stuff/releases/tag/math-renderer-v0.1.0-beta.1
Source: https://github.com/geoqiao/paseo-stuff/tree/main/plugins/math-renderer

## Caveats
Experimental, exactly Paseo app/daemon 0.8.0. Block math only, not inline math. Unsupported Markdown source rows stay native. Invalid, unsupported, oversized formulas and missing glyphs fall back to source. Native mobile and sustained multi-client load remain untested. Input limits are not a hard CPU/memory sandbox; plugins remain trusted code. Avoid a competing assistant-message replacement plugin. The entry exposes these limits before install.

## Verification
- Live GitHub repo/subpath/manifest-ID validation passed.
- 54 tests, typecheck/lint and clean Node 22/24 CI passed: https://github.com/geoqiao/paseo-stuff/actions/runs/34711345235
- Nine browser acceptance groups and actual macOS observations are recorded in plugin docs/verification.md; compact browser tests are not native-mobile acceptance.
- Cafe: offline validation of all 64 entries, check:app, website typecheck and canonical build passed; companion plugin typecheck and 104 tests passed on the same unchanged application/plugin code.
- On upstream main b9edc16, the full Cafe check already fails on .release-please-manifest.json formatting. Local website tests also reproduce one existing static-scan failure on macOS (214 pass, missing root-dependency finding). Registry-only changes do not touch those files; no unrelated fixes included.
- The requested bd CLI is unavailable locally.

Separate PR #97 migrates the existing Activity and DSH entries; this PR does not rename or duplicate them.