### PR TITLE
fix(security): resolve absolute registry paths in admission CLI

### DIFF
--- a/scripts/plugin-security/targets.cli.test.ts
+++ b/scripts/plugin-security/targets.cli.test.ts
@@ -1,0 +1,120 @@
+import { spawnSync } from "node:child_process"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it } from "vitest"
+
+const cli = fileURLToPath(new URL("./targets.ts", import.meta.url))
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true })
+})
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "security-target-cli-"))
+  roots.push(root)
+  const output = join(root, "targets.json")
+  const githubOutput = join(root, "github-output.txt")
+  const preload = join(root, "fetch.mjs")
+  writeFileSync(
+    preload,
+    `globalThis.fetch = async (url) => {
+      if (url !== "https://api.github.com/repos/owner/example/commits/HEAD")
+        throw new Error("Unexpected network request: " + url)
+      return new Response(JSON.stringify({ sha: "${"a".repeat(40)}" }))
+    }`
+  )
+  return {
+    root,
+    output,
+    githubOutput,
+    run(args: string[]) {
+      return spawnSync(
+        "bun",
+        ["--preload", preload, cli, ...args, "--output", output],
+        {
+          cwd: root,
+          env: { PATH: process.env.PATH, GITHUB_OUTPUT: githubOutput },
+          encoding: "utf8",
+          timeout: 10_000,
+        }
+      )
+    },
+  }
+}
+
+describe("security:targets CLI registry path", () => {
+  it.each([undefined, "relative registry"])(
+    "reads an empty registry with the default or relative path: %s",
+    (registryPath) => {
+      const f = fixture()
+      mkdirSync(join(f.root, registryPath ?? "registry"))
+      const result = f.run(registryPath ? ["--registry", registryPath] : [])
+      expect(result.error).toBeUndefined()
+      expect(result.status, result.stderr).toBe(0)
+      expect(JSON.parse(readFileSync(f.output, "utf8"))).toEqual({
+        version: 1,
+        targets: [],
+      })
+      expect(readFileSync(f.githubOutput, "utf8")).toBe("count=0\n")
+    }
+  )
+
+  it("reads the absolute registry path used by admission and resolves its target", () => {
+    const f = fixture()
+    const registry = join(f.root, "runner temp", "registry")
+    mkdirSync(registry, { recursive: true })
+    writeFileSync(
+      join(registry, "example.json"),
+      JSON.stringify({ repo: "owner/example", path: "plugins/example" })
+    )
+    const result = f.run(["--registry", registry])
+    expect(result.error).toBeUndefined()
+    expect(result.status, result.stderr).toBe(0)
+    expect(JSON.parse(readFileSync(f.output, "utf8"))).toEqual({
+      version: 1,
+      targets: [
+        {
+          id: "example",
+          repo: "owner/example",
+          path: "plugins/example",
+          ref: "a".repeat(40),
+          commit: "a".repeat(40),
+        },
+      ],
+    })
+    expect(readFileSync(f.githubOutput, "utf8")).toBe("count=1\n")
+  })
+
+  it("fails for a missing registry instead of emitting a clean empty result", () => {
+    const f = fixture()
+    const result = f.run(["--registry", join(f.root, "missing")])
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain("ENOENT")
+    expect(existsSync(f.output)).toBe(false)
+    expect(existsSync(f.githubOutput)).toBe(false)
+  })
+
+  it("still validates entries reached through an absolute registry path", () => {
+    const f = fixture()
+    const registry = join(f.root, "registry")
+    mkdirSync(registry)
+    writeFileSync(join(registry, "example.json"), "{not json}")
+    const result = f.run(["--registry", registry])
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain("JSON")
+    expect(result.stderr).not.toContain("ENOENT")
+    expect(existsSync(f.output)).toBe(false)
+    expect(existsSync(f.githubOutput)).toBe(false)
+  })
+})

--- a/scripts/plugin-security/targets.ts
+++ b/scripts/plugin-security/targets.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { readdirSync, readFileSync, writeFileSync } from "node:fs"
-import { basename, join } from "node:path"
+import { basename, join, resolve } from "node:path"
 import { z } from "zod"
 import {
   registryEntrySchema,
@@ -175,7 +175,7 @@ async function main() {
   const args = process.argv.slice(2)
   const outputPath = valueFor(args, "--output")
   if (!outputPath) throw new Error("missing --output")
-  const registryRoot = join(
+  const registryRoot = resolve(
     process.cwd(),
     valueFor(args, "--registry") ?? "registry"
   )


### PR DESCRIPTION
## Root cause
Registry admission creates an absolute directory under RUNNER_TEMP, then supplies it as --registry. targets.ts joins that absolute argument to process.cwd(), producing a duplicated path and ENOENT before scanning. This is reproducible on unchanged main b9edc16 and currently affects #97 and #98.

## Minimal fix
Use node:path resolve for the CLI registry root. Keep registry entry validation, target selection, scanning, trusted-base execution, report publishing and admission enforcement unchanged. No workflow, plugin, registry entry, dependency or release-version changes.

## Regression proof
Five real Bun CLI tests invoke targets.ts as a subprocess, with synthetic files and a narrowly mocked GitHub response (no network or inherited credentials):
- default registry and relative path with spaces;
- absolute path with spaces, a nonempty monorepo entry, resolved commit and count=1;
- missing directory fails without a misleading empty report;
- malformed JSON under the absolute path still fails validation.

Before the runtime fix: 2 failed, 3 passed, with the same duplicated-path ENOENT seen in CI. After: all 5 pass, plus all 4 existing target tests.

## Validation
- check:app and website typecheck passed.
- 220 website/security tests passed with TMPDIR canonicalized on macOS. The unrelated existing /var versus /private/var static-scan test issue is not changed here.
- Companion plugin typecheck and 104 tests passed.
- Canonical and fork-base-path builds passed.
- Live absolute-path target discovery followed by the unchanged scanner passed for all three published plugins, with zero blocking findings. This is supplemental local evidence, not a claim that PR admission has rerun successfully.
- Required full bun run check still encounters the existing .release-please-manifest.json formatting failure on unchanged main; kept out to minimize this admission fix.
- bd is not installed in this environment.

## Rollout
The privileged workflow intentionally executes trusted base code. Merge this fix first, then trigger #97/#98 against the new base so admission executes the fixed code. Do not bypass the scanner or switch execution to the fork head.