### PR TITLE
fix(ci): preserve absolute registry paths

### DIFF
--- a/scripts/plugin-security/targets.test.ts
+++ b/scripts/plugin-security/targets.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { selectTargets, writeCount } from "./targets.ts"
+import { resolveRegistryRoot, selectTargets, writeCount } from "./targets.ts"
 
 const responses = new Map<string, unknown>()
 const originalFetch = globalThis.fetch
@@ -170,5 +170,14 @@ describe("selectTargets", () => {
     process.env.GITHUB_OUTPUT = output
     writeCount(3)
     expect(readFileSync(output, "utf8")).toContain("count=3")
+  })
+
+  it("preserves absolute registry paths and resolves relative paths", () => {
+    expect(resolveRegistryRoot("/tmp/registry", "/workspace")).toBe(
+      "/tmp/registry"
+    )
+    expect(resolveRegistryRoot("registry", "/workspace")).toBe(
+      "/workspace/registry"
+    )
   })
 })

--- a/scripts/plugin-security/targets.ts
+++ b/scripts/plugin-security/targets.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { readdirSync, readFileSync, writeFileSync } from "node:fs"
-import { basename, join } from "node:path"
+import { basename, join, resolve } from "node:path"
 import { z } from "zod"
 import {
   registryEntrySchema,
@@ -175,8 +175,7 @@ async function main() {
   const args = process.argv.slice(2)
   const outputPath = valueFor(args, "--output")
   if (!outputPath) throw new Error("missing --output")
-  const registryRoot = join(
-    process.cwd(),
+  const registryRoot = resolveRegistryRoot(
     valueFor(args, "--registry") ?? "registry"
   )
   const eventPath = valueFor(args, "--event")
@@ -256,4 +255,8 @@ export function writeCount(count: number) {
 function valueFor(argv: string[], flag: string) {
   const i = argv.indexOf(flag)
   return i >= 0 ? argv[i + 1] : undefined
+}
+
+export function resolveRegistryRoot(path: string, cwd = process.cwd()) {
+  return resolve(cwd, path)
 }


### PR DESCRIPTION
## Summary
- resolve the registry CLI argument without prefixing absolute paths with the checkout directory
- add regression coverage for absolute and relative registry paths

## Cause
The registry admission workflow passes `$RUNNER_TEMP/registry`, but `path.join(process.cwd(), absolutePath)` produced a checkout-prefixed path on Bun/Node.

## Validation
- `bunx biome check --error-on-warnings scripts/plugin-security/targets.ts scripts/plugin-security/targets.test.ts`
- `bunx vitest run scripts/plugin-security/targets.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry path handling so absolute paths remain unchanged and relative paths resolve correctly from the selected workspace.
* **Tests**
  * Added coverage for registry path resolution in both absolute and relative path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->