### PR TITLE
feat(registry): add paseo-omp

### DIFF
--- a/registry/paseo-omp.json
+++ b/registry/paseo-omp.json
@@ -1,0 +1,10 @@
+{
+  "repo": "omercnet/paseo-plugins",
+  "path": "paseo-omp",
+  "categories": ["provider", "productivity", "orchestration"],
+  "caveats": [
+    "Alpha: requires Paseo 0.8.x, OMP 18.1.15+, and OMP RPC protocol v2.",
+    "Preview upgrades may require re-importing sessions created by an earlier version."
+  ],
+  "submittedBy": "omercnet"
+}


### PR DESCRIPTION
## What changed

Adds `paseo-omp` 0.1.0 to the community registry from `omercnet/paseo-plugins/paseo-omp`. The listing identifies it as an alpha provider and calls out its Paseo, OMP, and RPC protocol requirements.

## Plugin submissions and registry changes

- [x] `paseo-plugin.json.id` matches the registry filename.
- [x] `package.json.version` is the released semantic version `0.1.0`.
- [x] The repository and plugin path are public.

## Verification

- `bun run check:app`
- Parsed `registry/paseo-omp.json` with `registryEntrySchema`
- Confirmed the public plugin manifest ID is `paseo-omp` and package version is `0.1.0`
- Full local registry validation was blocked by GitHub API rate limiting; the submission CI runs with repository credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Paseo OMP plugin to the registry.
  * Included compatibility requirements and alpha-status caveats for using the plugin.
  * Added guidance about re-importing sessions after certain preview upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->