### PR TITLE
Create sayr.json

### DIFF
--- a/registry/sayr.json
+++ b/registry/sayr.json
@@ -1,0 +1,7 @@
+{
+  "repo": "dorasto/sayr",
+  "categories": ["productivity"],
+  "path": "packages/paseo-plugin",
+  "caveats":["Requires an account on Sayr.io","Requires the Sayr CLI to be authenticated"],
+  "submittedBy": "tommerty"
+}

--- a/registry/sayr.json
+++ b/registry/sayr.json
@@ -2,6 +2,9 @@
   "repo": "dorasto/sayr",
   "categories": ["productivity"],
   "path": "packages/paseo-plugin",
-  "caveats":["Requires an account on Sayr.io","Requires the Sayr CLI to be authenticated"],
+  "caveats": [
+    "Requires an account on Sayr.io",
+    "Requires the Sayr CLI to be authenticated"
+  ],
   "submittedBy": "tommerty"
 }


### PR DESCRIPTION
## Plugin submissions and registry changes

<!-- Delete this section when the pull request does not change registry/*.json. -->

- [x] `paseo-plugin.json.id` matches the registry filename.
- [x] For a new plugin submission, `package.json.version` is a released semantic version, not `0.0.0`.
- [x] The repository and plugin path are public.

Plugin releases do not require a Paseo Cafe PR. The catalog scanner reads releases from the plugin
repository automatically. The companion catalog uses `package.json.version` as the plugin's update
identity, so maintainers must increment it for each plugin-code release. Missing or invalid versions
appear as unavailable; the scanner flags `0.0.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Integrations**
  - Added Sayr.io to the available productivity integrations.
  - Documented account and authenticated CLI requirements for setup.
  - Added contributor attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->