### PR TITLE
Refresh Readable Agent Activity beta.6 listing caveats

### DIFF
--- a/registry/readable-agent-activity.json
+++ b/registry/readable-agent-activity.json
@@ -1,12 +1,14 @@
 {
   "repo": "geoqiao/paseo-stuff",
   "path": "plugins/agent-activity",
-  "categories": ["productivity"],
+  "categories": [
+    "productivity"
+  ],
   "caveats": [
     "Experimental beta: verified on Paseo 0.8.0, Full detail only; Summary is unsupported.",
     "All connected clients must use Full detail; disable before switching to Summary.",
-    "Do not enable alongside another tool/reasoning timeline replacement.",
-    "Show all and full Raw/copy can be expensive for very large payloads.",
+    "Do not enable alongside another tool-call or Thinking timeline replacement.",
+    "Show all and serialization can be expensive for very large payloads.",
     "macOS host tested; native iOS/Android untested."
   ],
   "submittedBy": "geoqiao"

--- a/registry/readable-agent-activity.json
+++ b/registry/readable-agent-activity.json
@@ -1,9 +1,7 @@
 {
   "repo": "geoqiao/paseo-stuff",
   "path": "plugins/agent-activity",
-  "categories": [
-    "productivity"
-  ],
+  "categories": ["productivity"],
   "caveats": [
     "Experimental beta: verified on Paseo 0.8.0, Full detail only; Summary is unsupported.",
     "All connected clients must use Full detail; disable before switching to Summary.",


### PR DESCRIPTION
## Existing listing update (not a new submission)

Readable Agent Activity **0.1.0-beta.6** is now on the canonical default branch:

- Source update: https://github.com/geoqiao/paseo-stuff/pull/3
- Release: https://github.com/geoqiao/paseo-stuff/releases/tag/readable-agent-activity-v0.1.0-beta.6
- README with three native-reference/plugin comparison screenshots: https://github.com/geoqiao/paseo-stuff/tree/main/plugins/agent-activity#before-and-after

This PR only updates the existing registry caveats:

- Remove the obsolete full Raw/copy warning; those controls were removed. Retain the large-payload serialization/Show all warning.
- Name the current tool-call/Thinking replacement conflict explicitly.
- Preserve the ID, source/subpath, Full detail-only requirement, unsupported Summary warning and native-mobile caveat.

The plugin package version is **0.1.0-beta.6**; there is intentionally no hand-maintained registry version field. The next scanner run will pick up the package version, README and the three new screenshot assets (obsolete images were removed from the current source).

Clean plugin install/check passed with 239 tests, including real Hermes evaluation. All eight Node 22/24 jobs in the source PR passed; browser checks cover wrapping, highlighting, manual disclosure and parent scrolling. The screenshots use identical synthetic data, with original Paseo's source-adapted renderer on the left and this plugin on the right; they are not device screenshots.

Please merge the caveat update and refresh the catalog when convenient (or let the scheduled six-hour scan deploy it). Publishing the GitHub release is not a claim that the static Cafe site has already refreshed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified compatibility caveats for the activity timeline, including restrictions on using it alongside other tool-call or Thinking timeline replacements.
  - Added a warning that displaying all entries and serialization may be expensive for large payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->